### PR TITLE
Avg compressor cycle time sensor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.5] - 2024-12-11
+
+### Added
+- New diagnostic sensor "Operation State" showing detailed heat pump operation mode
+- New diagnostic sensor "Compressor Cycle Time" measuring average time between compressor starts
+
+### Changed
+- Updated French and English translations for new sensors
+
 ## [1.3.4] - 2024-12-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.3.5] - 2024-12-11
+## [1.4.0] - 2024-12-11
 
 ### Added
 - New diagnostic sensor "Operation State" showing detailed heat pump operation mode

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-__VERSION__ = "1.3.4"
+__VERSION__ = "1.4.0"
 
 bump:
 	bump2version --allow-dirty --current-version $(__VERSION__) patch Makefile custom_components/hitachi_yutaki/const.py custom_components/hitachi_yutaki/manifest.json

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ This custom integration allows you to control and monitor your Hitachi Yutaki he
 
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=alepee&repository=hass-hitachi_yutaki)
 
-> ⚠️ **Beta Version - Under Development**  
+> ⚠️ **Beta Version - Under Development**
 > This integration is currently in active development and should be considered experimental. While it is functional, you may encounter bugs or incomplete features. Use at your own risk and please report any issues you find.
-> 
+>
 > Currently tested only with Yutaki S80 model. Testing with other models is in progress.
 
 ## Compatibility
@@ -66,6 +66,7 @@ The integration automatically detects your heat pump model and available feature
 | pump_speed | sensor | Current speed of the water circulation pump | % |
 | compressor_frequency | sensor | Current operating frequency of the compressor | Hz |
 | compressor_current | sensor | Current electrical consumption of the compressor | A |
+| compressor_cycle_time | sensor | Average time between compressor starts | min |
 | power_consumption | sensor | Total electrical energy consumed by the unit | kWh |
 
 #### R134a Circuit (S80 Model Only)

--- a/custom_components/hitachi_yutaki/const.py
+++ b/custom_components/hitachi_yutaki/const.py
@@ -8,7 +8,7 @@ DOMAIN = "hitachi_yutaki"
 MANUFACTURER = "Hitachi"
 GATEWAY_MODEL = "ATW-MBS-02"
 
-VERSION = "1.3.4"
+VERSION = "1.4.0"
 
 # Default values
 DEFAULT_NAME = "Hitachi Yutaki"

--- a/custom_components/hitachi_yutaki/const.py
+++ b/custom_components/hitachi_yutaki/const.py
@@ -1,4 +1,5 @@
 """Constants for the Hitachi Yutaki integration."""
+
 from homeassistant.const import (
     Platform,
 )
@@ -102,6 +103,7 @@ REGISTER_CONTROL = {
 
 # Sensor registers (addresses)
 REGISTER_SENSOR = {
+    "operation_state": 1090,
     "outdoor_temp": 1091,
     "water_inlet_temp": 1092,
     "water_outlet_temp": 1093,

--- a/custom_components/hitachi_yutaki/manifest.json
+++ b/custom_components/hitachi_yutaki/manifest.json
@@ -13,5 +13,5 @@
   "requirements": [
     "pymodbus==3.6.9"
   ],
-  "version": "1.3.4"
+  "version": "1.4.0"
 }

--- a/custom_components/hitachi_yutaki/translations/en.json
+++ b/custom_components/hitachi_yutaki/translations/en.json
@@ -60,6 +60,23 @@
   },
   "entity": {
     "sensor": {
+      "operation_state": {
+        "name": "Operation State",
+        "state": {
+          "operation_state_0": "Off",
+          "operation_state_1": "Cool Demand Off",
+          "operation_state_2": "Cool Regulation Off",
+          "operation_state_3": "Cool Regulation On",
+          "operation_state_4": "Heat Demand Off",
+          "operation_state_5": "Heat Regulation Off",
+          "operation_state_6": "Heat Regulation On",
+          "operation_state_7": "DHW Off",
+          "operation_state_8": "DHW On",
+          "operation_state_9": "Pool Off",
+          "operation_state_10": "Pool On",
+          "operation_state_11": "Alarm"
+        }
+      },
       "outdoor_temp": {
         "name": "Outdoor Temperature"
       },

--- a/custom_components/hitachi_yutaki/translations/en.json
+++ b/custom_components/hitachi_yutaki/translations/en.json
@@ -1,368 +1,371 @@
 {
-    "device": {
-        "gateway": {
-            "name": "Gateway"
-        },
-        "control_unit": {
-            "name": "Control Unit"
-        },
-        "primary_compressor": {
-            "name": "Outdoor Compressor"
-        },
-        "secondary_compressor": {
-            "name": "Indoor Compressor"
-        },
-        "circuit1": {
-            "name": "Circuit 1"
-        },
-        "circuit2": {
-            "name": "Circuit 2"
-        },
-        "dhw": {
-            "name": "DHW"
-        },
-        "pool": {
-            "name": "Pool"
-        }
+  "device": {
+    "gateway": {
+      "name": "Gateway"
     },
-    "config": {
-        "step": {
-            "user": {
-                "data": {
-                    "name": "Name",
-                    "host": "IP address",
-                    "show_advanced": "Show advanced settings"
-                },
-                "description": "Configure your Hitachi Yutaki heat pump via the Modbus TCP/IP interface exposed by the ATW-MBS-02 gateway. Important: your heat pump must be configured in 'Air' control mode to allow the gateway full read and write access to the heat pump control registers.",
-                "title": "Hitachi Yutaki"
-            },
-            "advanced": {
-                "data": {
-                    "port": "Port",
-                    "slave": "Modbus slave ID",
-                    "scan_interval": "Scan interval (seconds)",
-                    "dev_mode": "Developer mode (add all devices, even if they are not configured in the system)"
-                },
-                "description": "Advanced settings are intended for developers and users with custom Modbus configurations. Only modify these values if you know what you're doing.",
-                "title": "Advanced Settings"
-            }
-        },
-        "error": {
-            "cannot_connect": "Failed to connect",
-            "invalid_slave": "Invalid Modbus slave ID",
-            "modbus_error": "Modbus communication error",
-            "unknown": "Unexpected error",
-            "invalid_central_control_mode": "The heat pump must be configured in Central mode 'Air' (1). Possible modes: Local (0), Air (1), Water (2), Total (3). Please change this setting in your heat pump parameters. (System Configuration > General Options > External Control Option > Control Mode = Air)"
-        },
-        "abort": {
-            "already_configured": "Device is already configured"
-        }
+    "control_unit": {
+      "name": "Control Unit"
     },
-    "entity": {
-        "sensor": {
-            "outdoor_temp": {
-                "name": "Outdoor Temperature"
-            },
-            "water_inlet_temp": {
-                "name": "Water Inlet Temperature"
-            },
-            "water_outlet_temp": {
-                "name": "Water Outlet Temperature"
-            },
-            "water_target_temp": {
-                "name": "Corrected Target Temperature"
-            },
-            "water_flow": {
-                "name": "Water Flow"
-            },
-            "pump_speed": {
-                "name": "Pump Speed"
-            },
-            "compressor_frequency": {
-                "name": "Compressor Frequency"
-            },
-            "compressor_current": {
-                "name": "Compressor Current"
-            },
-            "compressor_tg_gas_temp": {
-                "name": "Gas Temperature"
-            },
-            "compressor_ti_liquid_temp": {
-                "name": "Liquid Temperature"
-            },
-            "compressor_td_discharge_temp": {
-                "name": "Discharge Temperature"
-            },
-            "compressor_te_evaporator_temp": {
-                "name": "Evaporator Temperature"
-            },
-            "compressor_evi_indoor_expansion_valve_opening": {
-                "name": "Indoor Expansion Valve Opening"
-            },
-            "compressor_evo_outdoor_expansion_valve_opening": {
-                "name": "Outdoor Expansion Valve Opening"
-            },
-            "power_consumption": {
-                "name": "Power Consumption"
-            },
-            "alarm_code": {
-                "name": "Alarm Code",
-                "state_attributes": {
-                    "description": {
-                        "state": {
-                            "alarm_code_0": "No Alarm",
-                            "alarm_code_2": "Activation of outdoor unit safety device",
-                            "alarm_code_3": "Abnormal transmission between indoor units and outdoor unit",
-                            "alarm_code_4": "Abnormal transmission between outdoor unit control PCB and inverter PCB",
-                            "alarm_code_5": "Phase detection signal abnormal operation code",
-                            "alarm_code_6": "Excessively low or high voltage for inverter",
-                            "alarm_code_7": "Decrease in discharge gas superheat",
-                            "alarm_code_8": "Excessive discharge gas temperature at top of compressor",
-                            "alarm_code_11": "Water inlet temperature thermistor abnormality (THMWI)",
-                            "alarm_code_12": "Water outlet temperature thermistor abnormality (THMWO)",
-                            "alarm_code_13": "Indoor R410A liquid pipe temperature thermistor abnormality (THML)",
-                            "alarm_code_14": "Indoor R410A gas pipe temperature thermistor abnormality (THMG)",
-                            "alarm_code_15": "Circuit 2 water outlet temperature thermistor abnormality (THMWO2)",
-                            "alarm_code_16": "DHW temperature thermistor abnormality (THMDHW)",
-                            "alarm_code_17": "Auxiliary sensor 2 abnormality (THMAUX2)",
-                            "alarm_code_18": "Universal sensor abnormality",
-                            "alarm_code_19": "Temperature thermistor abnormality",
-                            "alarm_code_20": "Discharge gas temperature thermistor abnormality",
-                            "alarm_code_21": "High pressure sensor abnormality",
-                            "alarm_code_22": "Outdoor temperature thermistor abnormality (THM7)",
-                            "alarm_code_23": "Discharge gas temperature thermistor abnormality (THM9)",
-                            "alarm_code_24": "Evaporation temperature thermistor abnormality during heating (THM8)",
-                            "alarm_code_25": "Auxiliary sensor 3 abnormality (THMAUX3)",
-                            "alarm_code_26": "Power or combined power setting error between indoor and outdoor unit",
-                            "alarm_code_35": "Power or combined power setting error between indoor and outdoor unit",
-                            "alarm_code_36": "Power or combined power setting error between indoor and outdoor unit",
-                            "alarm_code_38": "Protection circuit abnormality (outdoor unit)",
-                            "alarm_code_40": "Incorrect unit controller setting",
-                            "alarm_code_41": "High pressure switch overload",
-                            "alarm_code_42": "Heating overload (high pressure switch must be activated)",
-                            "alarm_code_45": "High pressure increase protection activation",
-                            "alarm_code_47": "System protection activation against insufficient suction pressure",
-                            "alarm_code_48": "Overcurrent protection activation",
-                            "alarm_code_51": "Current sensor abnormal operation",
-                            "alarm_code_53": "Transistor module activation",
-                            "alarm_code_54": "Inverter fin temperature abnormality",
-                            "alarm_code_57": "Fan motor protection abnormality (DC fan motor)",
-                            "alarm_code_70": "Water flow alarm and water pump malfunction",
-                            "alarm_code_72": "Water heater thermostat alarm",
-                            "alarm_code_73": "Mixed circuit maximum temperature limit protection",
-                            "alarm_code_74": "Unit temperature limit protection",
-                            "alarm_code_75": "Anti-freeze protection by cold water inlet/outlet temperature detection",
-                            "alarm_code_76": "Anti-freeze protection stop by indoor liquid temperature thermistor",
-                            "alarm_code_77": "Smart wireless receiver communication fault",
-                            "alarm_code_78": "RF communication fault",
-                            "alarm_code_79": "Incorrect power setting",
-                            "alarm_code_80": "H-LINK remote control communication fault",
-                            "alarm_code_81": "Momentary power interruption or Low voltage detected",
-                            "alarm_code_83": "Low pressure abnormality in hydraulic circuit",
-                            "alarm_code_101": "High pressure switch activation command",
-                            "alarm_code_102": "Excessive high pressure protection control activation",
-                            "alarm_code_104": "Low pressure protection control activation",
-                            "alarm_code_105": "Excessive low pressure difference",
-                            "alarm_code_106": "Excessive discharge gas temperature",
-                            "alarm_code_129": "Discharge gas pressure sensor failure",
-                            "alarm_code_130": "Suction gas pressure sensor failure",
-                            "alarm_code_132": "Transmission error between inverter PCB and main PCB",
-                            "alarm_code_134": "Power source phase abnormality control",
-                            "alarm_code_135": "Incorrect PCB setting",
-                            "alarm_code_151": "Inverter voltage abnormality control",
-                            "alarm_code_152": "Current sensor abnormal operation",
-                            "alarm_code_153": "Inverter overcurrent protection activation (I)",
-                            "alarm_code_154": "Transistor module protection activation",
-                            "alarm_code_155": "Inverter fin abnormality control",
-                            "alarm_code_156": "Inverter failure",
-                            "alarm_code_157": "Other abnormalities",
-                            "alarm_code_202": "Incorrect PC-ARF HE controller settings",
-                            "alarm_code_203": "Slave PC-ARFHE stop in response to master PC-ARFHE",
-                            "alarm_code_204": "Indoor unit loses communication with master PC-ARFHE",
-                            "alarm_code_205": "Central alarm, no central message"
-                        }
-                    }
-                }
-            },
-            "r134a_discharge_temp": {
-                "name": "R134a Discharge Temperature"
-            },
-            "r134a_suction_temp": {
-                "name": "R134a Suction Temperature"
-            },
-            "r134a_discharge_pressure": {
-                "name": "R134a Discharge Pressure"
-            },
-            "r134a_suction_pressure": {
-                "name": "R134a Suction Pressure"
-            },
-            "r134a_compressor_frequency": {
-                "name": "R134a Compressor Frequency"
-            },
-            "r134a_compressor_current": {
-                "name": "R134a Compressor Current"
-            }
-        },
-        "binary_sensor": {
-            "connectivity": {
-                "name": "Connectivity"
-            },
-            "defrost": {
-                "name": "Defrost"
-            },
-            "solar": {
-                "name": "Solar"
-            },
-            "pump1": {
-                "name": "Pump 1"
-            },
-            "pump2": {
-                "name": "Pump 2"
-            },
-            "pump3": {
-                "name": "Pump 3"
-            },
-            "compressor": {
-                "name": "Compressor"
-            },
-            "boiler": {
-                "name": "Boiler"
-            },
-            "dhw_heater": {
-                "name": "DHW Heater"
-            },
-            "space_heater": {
-                "name": "Space Heater"
-            },
-            "smart_function": {
-                "name": "Smart Function"
-            }
-        },
-        "select": {
-            "operation_mode_heat": {
-                "name": "Operation Mode",
-                "state": {
-                    "heat": "Heat",
-                    "auto": "Auto"
-                }
-            },
-            "operation_mode_full": {
-                "name": "Operation Mode",
-                "state": {
-                    "cool": "Cool",
-                    "heat": "Heat",
-                    "auto": "Auto"
-                }
-            },
-            "otc_calculation_method_heating": {
-                "name": "Heating Compensation Method",
-                "state": {
-                    "disabled": "Disabled",
-                    "points": "Points",
-                    "gradient": "Gradient",
-                    "fix": "Fix"
-                }
-            },
-            "otc_calculation_method_cooling": {
-                "name": "Cooling Compensation Method",
-                "state": {
-                    "disabled": "Disabled",
-                    "points": "Points",
-                    "fix": "Fix"
-                }
-            }
-        },
-        "switch": {
-            "power": {
-                "name": "Power"
-            },
-            "thermostat": {
-                "name": "Thermostat"
-            },
-            "eco_mode": {
-                "name": "ECO Mode"
-            },
-            "boost": {
-                "name": "Boost"
-            },
-            "high_demand": {
-                "name": "High Demand"
-            },
-            "antilegionella": {
-                "name": "Anti-legionella"
-            }
-        },
-        "number": {
-            "max_flow_temp_heating_otc": {
-                "name": "Maximum Flow Temperature Heating"
-            },
-            "max_flow_temp_cooling_otc": {
-                "name": "Maximum Flow Temperature Cooling"
-            },
-            "heat_eco_offset": {
-                "name": "Heat ECO Offset"
-            },
-            "cool_eco_offset": {
-                "name": "Cool ECO Offset"
-            },
-            "current_temp": {
-                "name": "Current Temperature"
-            },
-            "target_temp": {
-                "name": "Target Temperature"
-            },
-            "dhw_current_temperature": {
-                "name": "Current Temperature"
-            },
-            "dhw_target_temperature": {
-                "name": "Target Temperature"
-            },
-            "pool_current_temperature": {
-                "name": "Current Temperature"
-            },
-            "pool_target_temperature": {
-                "name": "Target Temperature"
-            },
-            "antilegionella_temp": {
-                "name": "Anti-legionella Temperature"
-            }
-        },
-        "climate": {
-            "climate": {
-                "name": "Climate Control",
-                "state": {
-                    "off": "Off",
-                    "heat": "Heat",
-                    "cool": "Cool",
-                    "auto": "Auto",
-                    "idle": "Idle",
-                    "defrost": "Defrost"
-                },
-                "state_attributes": {
-                    "preset_mode": {
-                        "state": {
-                            "eco": "Eco",
-                            "comfort": "Comfort"
-                        }
-                    }
-                }
-            },
-            "dhw_climate": {
-                "name": "DHW Control",
-                "state": {
-                    "off": "Off",
-                    "heat": "Heat"
-                },
-                "state_attributes": {
-                    "preset_mode": {
-                        "state": {
-                            "dhw_off": "Off",
-                            "dhw_standard": "Standard",
-                            "dhw_high_demand": "High Demand"
-                        }
-                    }
-                }
-            }
-        }
+    "primary_compressor": {
+      "name": "Outdoor Compressor"
+    },
+    "secondary_compressor": {
+      "name": "Indoor Compressor"
+    },
+    "circuit1": {
+      "name": "Circuit 1"
+    },
+    "circuit2": {
+      "name": "Circuit 2"
+    },
+    "dhw": {
+      "name": "DHW"
+    },
+    "pool": {
+      "name": "Pool"
     }
+  },
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "name": "Name",
+          "host": "IP address",
+          "show_advanced": "Show advanced settings"
+        },
+        "description": "Configure your Hitachi Yutaki heat pump via the Modbus TCP/IP interface exposed by the ATW-MBS-02 gateway. Important: your heat pump must be configured in 'Air' control mode to allow the gateway full read and write access to the heat pump control registers.",
+        "title": "Hitachi Yutaki"
+      },
+      "advanced": {
+        "data": {
+          "port": "Port",
+          "slave": "Modbus slave ID",
+          "scan_interval": "Scan interval (seconds)",
+          "dev_mode": "Developer mode (add all devices, even if they are not configured in the system)"
+        },
+        "description": "Advanced settings are intended for developers and users with custom Modbus configurations. Only modify these values if you know what you're doing.",
+        "title": "Advanced Settings"
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect",
+      "invalid_slave": "Invalid Modbus slave ID",
+      "modbus_error": "Modbus communication error",
+      "unknown": "Unexpected error",
+      "invalid_central_control_mode": "The heat pump must be configured in Central mode 'Air' (1). Possible modes: Local (0), Air (1), Water (2), Total (3). Please change this setting in your heat pump parameters. (System Configuration > General Options > External Control Option > Control Mode = Air)"
+    },
+    "abort": {
+      "already_configured": "Device is already configured"
+    }
+  },
+  "entity": {
+    "sensor": {
+      "outdoor_temp": {
+        "name": "Outdoor Temperature"
+      },
+      "water_inlet_temp": {
+        "name": "Water Inlet Temperature"
+      },
+      "water_outlet_temp": {
+        "name": "Water Outlet Temperature"
+      },
+      "water_target_temp": {
+        "name": "Corrected Target Temperature"
+      },
+      "water_flow": {
+        "name": "Water Flow"
+      },
+      "pump_speed": {
+        "name": "Pump Speed"
+      },
+      "compressor_frequency": {
+        "name": "Compressor Frequency"
+      },
+      "compressor_current": {
+        "name": "Compressor Current"
+      },
+      "compressor_cycle_time": {
+        "name": "Compressor Cycle Time"
+      },
+      "compressor_tg_gas_temp": {
+        "name": "Gas Temperature"
+      },
+      "compressor_ti_liquid_temp": {
+        "name": "Liquid Temperature"
+      },
+      "compressor_td_discharge_temp": {
+        "name": "Discharge Temperature"
+      },
+      "compressor_te_evaporator_temp": {
+        "name": "Evaporator Temperature"
+      },
+      "compressor_evi_indoor_expansion_valve_opening": {
+        "name": "Indoor Expansion Valve Opening"
+      },
+      "compressor_evo_outdoor_expansion_valve_opening": {
+        "name": "Outdoor Expansion Valve Opening"
+      },
+      "power_consumption": {
+        "name": "Power Consumption"
+      },
+      "alarm_code": {
+        "name": "Alarm Code",
+        "state_attributes": {
+          "description": {
+            "state": {
+              "alarm_code_0": "No Alarm",
+              "alarm_code_2": "Activation of outdoor unit safety device",
+              "alarm_code_3": "Abnormal transmission between indoor units and outdoor unit",
+              "alarm_code_4": "Abnormal transmission between outdoor unit control PCB and inverter PCB",
+              "alarm_code_5": "Phase detection signal abnormal operation code",
+              "alarm_code_6": "Excessively low or high voltage for inverter",
+              "alarm_code_7": "Decrease in discharge gas superheat",
+              "alarm_code_8": "Excessive discharge gas temperature at top of compressor",
+              "alarm_code_11": "Water inlet temperature thermistor abnormality (THMWI)",
+              "alarm_code_12": "Water outlet temperature thermistor abnormality (THMWO)",
+              "alarm_code_13": "Indoor R410A liquid pipe temperature thermistor abnormality (THML)",
+              "alarm_code_14": "Indoor R410A gas pipe temperature thermistor abnormality (THMG)",
+              "alarm_code_15": "Circuit 2 water outlet temperature thermistor abnormality (THMWO2)",
+              "alarm_code_16": "DHW temperature thermistor abnormality (THMDHW)",
+              "alarm_code_17": "Auxiliary sensor 2 abnormality (THMAUX2)",
+              "alarm_code_18": "Universal sensor abnormality",
+              "alarm_code_19": "Temperature thermistor abnormality",
+              "alarm_code_20": "Discharge gas temperature thermistor abnormality",
+              "alarm_code_21": "High pressure sensor abnormality",
+              "alarm_code_22": "Outdoor temperature thermistor abnormality (THM7)",
+              "alarm_code_23": "Discharge gas temperature thermistor abnormality (THM9)",
+              "alarm_code_24": "Evaporation temperature thermistor abnormality during heating (THM8)",
+              "alarm_code_25": "Auxiliary sensor 3 abnormality (THMAUX3)",
+              "alarm_code_26": "Power or combined power setting error between indoor and outdoor unit",
+              "alarm_code_35": "Power or combined power setting error between indoor and outdoor unit",
+              "alarm_code_36": "Power or combined power setting error between indoor and outdoor unit",
+              "alarm_code_38": "Protection circuit abnormality (outdoor unit)",
+              "alarm_code_40": "Incorrect unit controller setting",
+              "alarm_code_41": "High pressure switch overload",
+              "alarm_code_42": "Heating overload (high pressure switch must be activated)",
+              "alarm_code_45": "High pressure increase protection activation",
+              "alarm_code_47": "System protection activation against insufficient suction pressure",
+              "alarm_code_48": "Overcurrent protection activation",
+              "alarm_code_51": "Current sensor abnormal operation",
+              "alarm_code_53": "Transistor module activation",
+              "alarm_code_54": "Inverter fin temperature abnormality",
+              "alarm_code_57": "Fan motor protection abnormality (DC fan motor)",
+              "alarm_code_70": "Water flow alarm and water pump malfunction",
+              "alarm_code_72": "Water heater thermostat alarm",
+              "alarm_code_73": "Mixed circuit maximum temperature limit protection",
+              "alarm_code_74": "Unit temperature limit protection",
+              "alarm_code_75": "Anti-freeze protection by cold water inlet/outlet temperature detection",
+              "alarm_code_76": "Anti-freeze protection stop by indoor liquid temperature thermistor",
+              "alarm_code_77": "Smart wireless receiver communication fault",
+              "alarm_code_78": "RF communication fault",
+              "alarm_code_79": "Incorrect power setting",
+              "alarm_code_80": "H-LINK remote control communication fault",
+              "alarm_code_81": "Momentary power interruption or Low voltage detected",
+              "alarm_code_83": "Low pressure abnormality in hydraulic circuit",
+              "alarm_code_101": "High pressure switch activation command",
+              "alarm_code_102": "Excessive high pressure protection control activation",
+              "alarm_code_104": "Low pressure protection control activation",
+              "alarm_code_105": "Excessive low pressure difference",
+              "alarm_code_106": "Excessive discharge gas temperature",
+              "alarm_code_129": "Discharge gas pressure sensor failure",
+              "alarm_code_130": "Suction gas pressure sensor failure",
+              "alarm_code_132": "Transmission error between inverter PCB and main PCB",
+              "alarm_code_134": "Power source phase abnormality control",
+              "alarm_code_135": "Incorrect PCB setting",
+              "alarm_code_151": "Inverter voltage abnormality control",
+              "alarm_code_152": "Current sensor abnormal operation",
+              "alarm_code_153": "Inverter overcurrent protection activation (I)",
+              "alarm_code_154": "Transistor module protection activation",
+              "alarm_code_155": "Inverter fin abnormality control",
+              "alarm_code_156": "Inverter failure",
+              "alarm_code_157": "Other abnormalities",
+              "alarm_code_202": "Incorrect PC-ARF HE controller settings",
+              "alarm_code_203": "Slave PC-ARFHE stop in response to master PC-ARFHE",
+              "alarm_code_204": "Indoor unit loses communication with master PC-ARFHE",
+              "alarm_code_205": "Central alarm, no central message"
+            }
+          }
+        }
+      },
+      "r134a_discharge_temp": {
+        "name": "R134a Discharge Temperature"
+      },
+      "r134a_suction_temp": {
+        "name": "R134a Suction Temperature"
+      },
+      "r134a_discharge_pressure": {
+        "name": "R134a Discharge Pressure"
+      },
+      "r134a_suction_pressure": {
+        "name": "R134a Suction Pressure"
+      },
+      "r134a_compressor_frequency": {
+        "name": "R134a Compressor Frequency"
+      },
+      "r134a_compressor_current": {
+        "name": "R134a Compressor Current"
+      }
+    },
+    "binary_sensor": {
+      "connectivity": {
+        "name": "Connectivity"
+      },
+      "defrost": {
+        "name": "Defrost"
+      },
+      "solar": {
+        "name": "Solar"
+      },
+      "pump1": {
+        "name": "Pump 1"
+      },
+      "pump2": {
+        "name": "Pump 2"
+      },
+      "pump3": {
+        "name": "Pump 3"
+      },
+      "compressor": {
+        "name": "Compressor"
+      },
+      "boiler": {
+        "name": "Boiler"
+      },
+      "dhw_heater": {
+        "name": "DHW Heater"
+      },
+      "space_heater": {
+        "name": "Space Heater"
+      },
+      "smart_function": {
+        "name": "Smart Function"
+      }
+    },
+    "select": {
+      "operation_mode_heat": {
+        "name": "Operation Mode",
+        "state": {
+          "heat": "Heat",
+          "auto": "Auto"
+        }
+      },
+      "operation_mode_full": {
+        "name": "Operation Mode",
+        "state": {
+          "cool": "Cool",
+          "heat": "Heat",
+          "auto": "Auto"
+        }
+      },
+      "otc_calculation_method_heating": {
+        "name": "Heating Compensation Method",
+        "state": {
+          "disabled": "Disabled",
+          "points": "Points",
+          "gradient": "Gradient",
+          "fix": "Fix"
+        }
+      },
+      "otc_calculation_method_cooling": {
+        "name": "Cooling Compensation Method",
+        "state": {
+          "disabled": "Disabled",
+          "points": "Points",
+          "fix": "Fix"
+        }
+      }
+    },
+    "switch": {
+      "power": {
+        "name": "Power"
+      },
+      "thermostat": {
+        "name": "Thermostat"
+      },
+      "eco_mode": {
+        "name": "ECO Mode"
+      },
+      "boost": {
+        "name": "Boost"
+      },
+      "high_demand": {
+        "name": "High Demand"
+      },
+      "antilegionella": {
+        "name": "Anti-legionella"
+      }
+    },
+    "number": {
+      "max_flow_temp_heating_otc": {
+        "name": "Maximum Flow Temperature Heating"
+      },
+      "max_flow_temp_cooling_otc": {
+        "name": "Maximum Flow Temperature Cooling"
+      },
+      "heat_eco_offset": {
+        "name": "Heat ECO Offset"
+      },
+      "cool_eco_offset": {
+        "name": "Cool ECO Offset"
+      },
+      "current_temp": {
+        "name": "Current Temperature"
+      },
+      "target_temp": {
+        "name": "Target Temperature"
+      },
+      "dhw_current_temperature": {
+        "name": "Current Temperature"
+      },
+      "dhw_target_temperature": {
+        "name": "Target Temperature"
+      },
+      "pool_current_temperature": {
+        "name": "Current Temperature"
+      },
+      "pool_target_temperature": {
+        "name": "Target Temperature"
+      },
+      "antilegionella_temp": {
+        "name": "Anti-legionella Temperature"
+      }
+    },
+    "climate": {
+      "climate": {
+        "name": "Climate Control",
+        "state": {
+          "off": "Off",
+          "heat": "Heat",
+          "cool": "Cool",
+          "auto": "Auto",
+          "idle": "Idle",
+          "defrost": "Defrost"
+        },
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "eco": "Eco",
+              "comfort": "Comfort"
+            }
+          }
+        }
+      },
+      "dhw_climate": {
+        "name": "DHW Control",
+        "state": {
+          "off": "Off",
+          "heat": "Heat"
+        },
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "dhw_off": "Off",
+              "dhw_standard": "Standard",
+              "dhw_high_demand": "High Demand"
+            }
+          }
+        }
+      }
+    }
+  }
 }

--- a/custom_components/hitachi_yutaki/translations/fr.json
+++ b/custom_components/hitachi_yutaki/translations/fr.json
@@ -1,368 +1,371 @@
 {
-    "device": {
-        "gateway": {
-            "name": "Passerelle"
-        },
-        "control_unit": {
-            "name": "Unité de Contrôle"
-        },
-        "primary_compressor": {
-            "name": "Compresseur Extérieur"
-        },
-        "secondary_compressor": {
-            "name": "Compresseur Intérieur"
-        },
-        "circuit1": {
-            "name": "Circuit 1"
-        },
-        "circuit2": {
-            "name": "Circuit 2"
-        },
-        "dhw": {
-            "name": "ECS"
-        },
-        "pool": {
-            "name": "Piscine"
-        }
+  "device": {
+    "gateway": {
+      "name": "Passerelle"
     },
-    "config": {
-        "step": {
-            "user": {
-                "data": {
-                    "name": "Nom",
-                    "host": "Adresse IP",
-                    "show_advanced": "Afficher les paramètres avancés"
-                },
-                "description": "Configurez votre pompe à chaleur Hitachi Yutaki via l'interface Modbus TCP/IP exposée par la passerelle ATW-MBS-02. Important : votre pompe à chaleur doit être configurée en mode de contrôle 'Air' pour permettre à la passerelle d'avoir un accès complet en lecture et écriture aux registres de contrôle de la pompe à chaleur.",
-                "title": "Hitachi Yutaki"
-            },
-            "advanced": {
-                "data": {
-                    "port": "Port",
-                    "slave": "ID esclave Modbus",
-                    "scan_interval": "Intervalle de scan (secondes)",
-                    "dev_mode": "Mode développeur (ajoute tous les devices, même s'ils ne sont pas configurés dans le système)"
-                },
-                "description": "Les paramètres avancés sont destinés aux développeurs et aux utilisateurs ayant une configuration Modbus personnalisée. Ne modifiez ces valeurs que si vous savez ce que vous faites.",
-                "title": "Paramètres avancés"
-            }
-        },
-        "error": {
-            "cannot_connect": "Échec de connexion",
-            "invalid_slave": "ID esclave Modbus invalide",
-            "modbus_error": "Erreur de communication Modbus",
-            "unknown": "Erreur inattendue",
-            "invalid_central_control_mode": "La pompe à chaleur doit être configurée en mode Central 'Air' (1). Modes possibles : Local (0), Air (1), Water (2), Total (3). Veuillez modifier ce réglage dans les paramètres de votre pompe à chaleur (Configuration du système > Options générales > Option commande externe > Mode de controle = Air)."
-        },
-        "abort": {
-            "already_configured": "L'appareil est déjà configuré"
-        }
+    "control_unit": {
+      "name": "Unité de Contrôle"
     },
-    "entity": {
-        "sensor": {
-            "outdoor_temp": {
-                "name": "Température Extérieure"
-            },
-            "water_inlet_temp": {
-                "name": "Température d'Entrée d'Eau"
-            },
-            "water_outlet_temp": {
-                "name": "Température de Sortie d'Eau"
-            },
-            "water_target_temp": {
-                "name": "Température Cible Corrigée"
-            },
-            "water_flow": {
-                "name": "Débit d'Eau"
-            },
-            "pump_speed": {
-                "name": "Vitesse de Pompe"
-            },
-            "compressor_frequency": {
-                "name": "Fréquence du Compresseur"
-            },
-            "compressor_current": {
-                "name": "Courant du Compresseur"
-            },
-            "compressor_tg_gas_temp": {
-                "name": "Température du Gaz"
-            },
-            "compressor_ti_liquid_temp": {
-                "name": "Température du Liquide"
-            },
-            "compressor_td_discharge_temp": {
-                "name": "Température de Refoulement"
-            },
-            "compressor_te_evaporator_temp": {
-                "name": "Température d'Évaporation"
-            },
-            "compressor_evi_indoor_expansion_valve_opening": {
-                "name": "Ouverture Vanne d'Expansion Intérieure"
-            },
-            "compressor_evo_outdoor_expansion_valve_opening": {
-                "name": "Ouverture Vanne d'Expansion Extérieure"
-            },
-            "power_consumption": {
-                "name": "Consommation Électrique"
-            },
-            "alarm_code": {
-                "name": "Code d'Alarme",
-                "state_attributes": {
-                    "description": {
-                        "state": {
-                            "alarm_code_0": "Pas d'alarme",
-                            "alarm_code_2": "Activation du dispositif de sécurité du groupe extérieur",
-                            "alarm_code_3": "Transmission anormale entre les unités intérieures et le groupe extérieur",
-                            "alarm_code_4": "Transmission anormale entre la PCB de commande et la PCB de l'inverter du groupe extérieur",
-                            "alarm_code_5": "Code de fonctionnement anormal du captage du signal de phase",
-                            "alarm_code_6": "Tension excessivement basse ou élevée pour l'inverter",
-                            "alarm_code_7": "Baisse de la surchauffe de gaz de refoulement",
-                            "alarm_code_8": "Température du gaz de refoulement excessive en haut du compresseur",
-                            "alarm_code_11": "Anomalie de la thermistance de température d'arrivée de l'eau (THMWI)",
-                            "alarm_code_12": "Anomalie de la thermistance de la température de sortie de l'eau (THMWO)",
-                            "alarm_code_13": "Anomalie de la thermistance de température de la tuyauterie de liquide intérieure R410A (THML)",
-                            "alarm_code_14": "Anomalie de la thermistance de température de la tuyauterie de gaz intérieure R410A (THMG)",
-                            "alarm_code_15": "Anomalie de la thermistance de la température de sortie de l'eau du circuit 2 (THMWO2)",
-                            "alarm_code_16": "Anomalie de la thermistance de la température de l'eau chaude sanitaire (THMDHW)",
-                            "alarm_code_17": "Anomalie du capteur de température auxiliaire 2 (THMAUX2)",
-                            "alarm_code_18": "Capteur universel",
-                            "alarm_code_19": "Anomalie de la thermistance de la température",
-                            "alarm_code_20": "Anomalie de la thermistance de la température du gaz de refoulement",
-                            "alarm_code_21": "Anomalie de capteur haute pression",
-                            "alarm_code_22": "Fonctionnement anormal de la thermistance de la température extérieure (THM7)",
-                            "alarm_code_23": "Fonctionnement anormal de la thermistance du gaz de refoulement (THM9)",
-                            "alarm_code_24": "Fonctionnement anormal de la thermistance de la température d'évaporation pendant le chauffage (THM8)",
-                            "alarm_code_25": "Anomalie de la thermistance du capteur auxiliaire 3 (THMAUX3)",
-                            "alarm_code_26": "Erreur de réglage de puissance ou de puissance combinée entre unité intérieure et groupe extérieur",
-                            "alarm_code_35": "Erreur de réglage de puissance ou de puissance combinée entre unité intérieure et groupe extérieur",
-                            "alarm_code_36": "Erreur de réglage de puissance ou de puissance combinée entre unité intérieure et groupe extérieur",
-                            "alarm_code_38": "Anomalie du circuit de protection (groupe extérieur)",
-                            "alarm_code_40": "Réglage incorrect du contrôleur d'unité",
-                            "alarm_code_41": "Surcharge du pressostat de haute pression",
-                            "alarm_code_42": "Surcharge en chauffage (le pressostat haute pression doit être activé)",
-                            "alarm_code_45": "Activation de l'organe de protection contre l'augmentation de la haute pression",
-                            "alarm_code_47": "Déclenchement de la protection du système contre une pression d'aspiration insuffisante",
-                            "alarm_code_48": "Activation de la protection de surintensité",
-                            "alarm_code_51": "Fonctionnement anormal de sonde d'intensité",
-                            "alarm_code_53": "Activation du module de transistor",
-                            "alarm_code_54": "Anomalie de température d'ailette de l'inverter",
-                            "alarm_code_57": "Anomalie de la protection du moteur du ventilateur (moteur du ventilateur CC)",
-                            "alarm_code_70": "Alarme du débit hydraulique et dysfonctionnement de la pompe à eau",
-                            "alarm_code_72": "Alarme du thermostat du chauffe-eau",
-                            "alarm_code_73": "Mélange de la protection de limite de température maxi. pour le circuit mixte",
-                            "alarm_code_74": "Protection de limite de température de l'unité",
-                            "alarm_code_75": "Protection antigel par détection de la température d'entrée/sortie d'eau froide",
-                            "alarm_code_76": "Arrêt de la protection anti-gel par le thermistor de température des liquides intérieur",
-                            "alarm_code_77": "Défaut de la communication du récepteur sans fil intelligent",
-                            "alarm_code_78": "Défaut de la communication RF",
-                            "alarm_code_79": "Réglage incorrect de la puissance",
-                            "alarm_code_80": "Défaut de communication télécommande H-LINK",
-                            "alarm_code_81": "Interruption momentanée de l'alimentation ou Basse tension détectée",
-                            "alarm_code_83": "Anomalie de la basse pression dans le circuit hydraulique",
-                            "alarm_code_101": "Commande d'activation du pressostat haute pression",
-                            "alarm_code_102": "Activation du contrôle de la protection pour une excessive haute pression",
-                            "alarm_code_104": "Activation du contrôle de la protection en raison d'une basse pression",
-                            "alarm_code_105": "Différence de basse pression excessive",
-                            "alarm_code_106": "Température du gaz de refoulement excessive",
-                            "alarm_code_129": "Défaillance du capteur de pression du gaz de refoulement",
-                            "alarm_code_130": "Défaillance du capteur de pression du gaz d'aspiration",
-                            "alarm_code_132": "Erreur de transmission entre la PCB de l'inverter et la PCB principale",
-                            "alarm_code_134": "Contrôle des anomalités de la phase de la source d'alimentation",
-                            "alarm_code_135": "Réglage incorrect de PCB",
-                            "alarm_code_151": "Contrôle des anomalies de tension de l'inverter",
-                            "alarm_code_152": "Fonctionnement anormal de sonde d'intensité",
-                            "alarm_code_153": "Activation de protection contre la surintensité de l'inverter (I)",
-                            "alarm_code_154": "Activation de la protection du module de transistor",
-                            "alarm_code_155": "Contrôle des anomalies de l'ailette de l'inverter",
-                            "alarm_code_156": "Panne de l'inverter",
-                            "alarm_code_157": "Autres anomalies",
-                            "alarm_code_202": "Réglages incorrectes du contrôleur PC-ARF HE",
-                            "alarm_code_203": "Arrêt de PC-ARFHE esclave en réponse au PC-ARFHE maître",
-                            "alarm_code_204": "L'unité intérieure perd la communication avec le PC-ARFHE maître",
-                            "alarm_code_205": "Alarme centrale, aucun message central"
-                        }
-                    }
-                }
-            },
-            "r134a_discharge_temp": {
-                "name": "Température de Refoulement R134a"
-            },
-            "r134a_suction_temp": {
-                "name": "Température d'Aspiration R134a"
-            },
-            "r134a_discharge_pressure": {
-                "name": "Pression de Refoulement R134a"
-            },
-            "r134a_suction_pressure": {
-                "name": "Pression d'Aspiration R134a"
-            },
-            "r134a_compressor_frequency": {
-                "name": "Fréquence du Compresseur R134a"
-            },
-            "r134a_compressor_current": {
-                "name": "Courant du Compresseur R134a"
-            }
-        },
-        "binary_sensor": {
-            "connectivity": {
-                "name": "Connectivité"
-            },
-            "defrost": {
-                "name": "Dégivrage"
-            },
-            "solar": {
-                "name": "Solaire"
-            },
-            "pump1": {
-                "name": "Pompe 1"
-            },
-            "pump2": {
-                "name": "Pompe 2"
-            },
-            "pump3": {
-                "name": "Pompe 3"
-            },
-            "compressor": {
-                "name": "Compresseur"
-            },
-            "boiler": {
-                "name": "Chaudière"
-            },
-            "dhw_heater": {
-                "name": "Chauffage ECS"
-            },
-            "space_heater": {
-                "name": "Chauffage d'Appoint"
-            },
-            "smart_function": {
-                "name": "Fonction Smart"
-            }
-        },
-        "select": {
-            "operation_mode_heat": {
-                "name": "Mode de Fonctionnement",
-                "state": {
-                    "heat": "Chauffage",
-                    "auto": "Auto"
-                }
-            },
-            "operation_mode_full": {
-                "name": "Mode de Fonctionnement",
-                "state": {
-                    "cool": "Refroidissement",
-                    "heat": "Chauffage",
-                    "auto": "Auto"
-                }
-            },
-            "otc_calculation_method_heating": {
-                "name": "Méthode de Compensation Chauffage",
-                "state": {
-                    "disabled": "Désactivé",
-                    "points": "Points",
-                    "gradient": "Gradient",
-                    "fix": "Fixe"
-                }
-            },
-            "otc_calculation_method_cooling": {
-                "name": "Méthode de Compensation Refroidissement",
-                "state": {
-                    "disabled": "Désactivé",
-                    "points": "Points",
-                    "fix": "Fixe"
-                }
-            }
-        },
-        "switch": {
-            "power": {
-                "name": "Alimentation"
-            },
-            "thermostat": {
-                "name": "Thermostat"
-            },
-            "eco_mode": {
-                "name": "Mode ECO"
-            },
-            "boost": {
-                "name": "Forçage ECS"
-            },
-            "high_demand": {
-                "name": "Demande intense"
-            },
-            "antilegionella": {
-                "name": "Anti-légionelle"
-            }
-        },
-        "number": {
-            "max_flow_temp_heating_otc": {
-                "name": "Température de départ maximum en chauffage"
-            },
-            "max_flow_temp_cooling_otc": {
-                "name": "Température de départ maximum en refroidissement"
-            },
-            "heat_eco_offset": {
-                "name": "Décalage ECO Chauffage"
-            },
-            "cool_eco_offset": {
-                "name": "Décalage ECO Refroidissement"
-            },
-            "current_temp": {
-                "name": "Température Ambiante"
-            },
-            "target_temp": {
-                "name": "Température Cible"
-            },
-            "dhw_current_temperature": {
-                "name": "Température Actuelle"
-            },
-            "dhw_target_temperature": {
-                "name": "Température Cible"
-            },
-            "pool_current_temperature": {
-                "name": "Température Actuelle"
-            },
-            "pool_target_temperature": {
-                "name": "Température Cible"
-            },
-            "antilegionella_temp": {
-                "name": "Température Anti-légionelle"
-            }
-        },
-        "climate": {
-            "climate": {
-                "name": "Contrôle Climatique",
-                "state": {
-                    "off": "Arrêt",
-                    "heat": "Chauffage",
-                    "cool": "Refroidissement",
-                    "auto": "Auto",
-                    "idle": "Inactif",
-                    "defrost": "Dégivrage"
-                },
-                "state_attributes": {
-                    "preset_mode": {
-                        "state": {
-                            "eco": "Éco",
-                            "comfort": "Confort"
-                        }
-                    }
-                }
-            },
-            "dhw_climate": {
-                "name": "Contrôle ECS",
-                "state": {
-                    "off": "Arrêt",
-                    "heat": "Chauffage"
-                },
-                "state_attributes": {
-                    "preset_mode": {
-                        "state": {
-                            "dhw_off": "Arrêt",
-                            "dhw_standard": "Standard",
-                            "dhw_high_demand": "Haute Demande"
-                        }
-                    }
-                }
-            }
-        }
+    "primary_compressor": {
+      "name": "Compresseur Extérieur"
+    },
+    "secondary_compressor": {
+      "name": "Compresseur Intérieur"
+    },
+    "circuit1": {
+      "name": "Circuit 1"
+    },
+    "circuit2": {
+      "name": "Circuit 2"
+    },
+    "dhw": {
+      "name": "ECS"
+    },
+    "pool": {
+      "name": "Piscine"
     }
+  },
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "name": "Nom",
+          "host": "Adresse IP",
+          "show_advanced": "Afficher les paramètres avancés"
+        },
+        "description": "Configurez votre pompe à chaleur Hitachi Yutaki via l'interface Modbus TCP/IP exposée par la passerelle ATW-MBS-02. Important : votre pompe à chaleur doit être configurée en mode de contrôle 'Air' pour permettre à la passerelle d'avoir un accès complet en lecture et écriture aux registres de contrôle de la pompe à chaleur.",
+        "title": "Hitachi Yutaki"
+      },
+      "advanced": {
+        "data": {
+          "port": "Port",
+          "slave": "ID esclave Modbus",
+          "scan_interval": "Intervalle de scan (secondes)",
+          "dev_mode": "Mode développeur (ajoute tous les devices, même s'ils ne sont pas configurés dans le système)"
+        },
+        "description": "Les paramètres avancés sont destinés aux développeurs et aux utilisateurs ayant une configuration Modbus personnalisée. Ne modifiez ces valeurs que si vous savez ce que vous faites.",
+        "title": "Paramètres avancés"
+      }
+    },
+    "error": {
+      "cannot_connect": "Échec de connexion",
+      "invalid_slave": "ID esclave Modbus invalide",
+      "modbus_error": "Erreur de communication Modbus",
+      "unknown": "Erreur inattendue",
+      "invalid_central_control_mode": "La pompe à chaleur doit être configurée en mode Central 'Air' (1). Modes possibles : Local (0), Air (1), Water (2), Total (3). Veuillez modifier ce réglage dans les paramètres de votre pompe à chaleur (Configuration du système > Options générales > Option commande externe > Mode de controle = Air)."
+    },
+    "abort": {
+      "already_configured": "L'appareil est déjà configuré"
+    }
+  },
+  "entity": {
+    "sensor": {
+      "outdoor_temp": {
+        "name": "Température Extérieure"
+      },
+      "water_inlet_temp": {
+        "name": "Température d'Entrée d'Eau"
+      },
+      "water_outlet_temp": {
+        "name": "Température de Sortie d'Eau"
+      },
+      "water_target_temp": {
+        "name": "Température Cible Corrigée"
+      },
+      "water_flow": {
+        "name": "Débit d'Eau"
+      },
+      "pump_speed": {
+        "name": "Vitesse de Pompe"
+      },
+      "compressor_frequency": {
+        "name": "Fréquence du Compresseur"
+      },
+      "compressor_current": {
+        "name": "Courant du Compresseur"
+      },
+      "compressor_cycle_time": {
+        "name": "Temps de Cycle Compresseur"
+      },
+      "compressor_tg_gas_temp": {
+        "name": "Température du Gaz"
+      },
+      "compressor_ti_liquid_temp": {
+        "name": "Température du Liquide"
+      },
+      "compressor_td_discharge_temp": {
+        "name": "Température de Refoulement"
+      },
+      "compressor_te_evaporator_temp": {
+        "name": "Température d'Évaporation"
+      },
+      "compressor_evi_indoor_expansion_valve_opening": {
+        "name": "Ouverture Vanne d'Expansion Intérieure"
+      },
+      "compressor_evo_outdoor_expansion_valve_opening": {
+        "name": "Ouverture Vanne d'Expansion Extérieure"
+      },
+      "power_consumption": {
+        "name": "Consommation Électrique"
+      },
+      "alarm_code": {
+        "name": "Code d'Alarme",
+        "state_attributes": {
+          "description": {
+            "state": {
+              "alarm_code_0": "Pas d'alarme",
+              "alarm_code_2": "Activation du dispositif de sécurité du groupe extérieur",
+              "alarm_code_3": "Transmission anormale entre les unités intérieures et le groupe extérieur",
+              "alarm_code_4": "Transmission anormale entre la PCB de commande et la PCB de l'inverter du groupe extérieur",
+              "alarm_code_5": "Code de fonctionnement anormal du captage du signal de phase",
+              "alarm_code_6": "Tension excessivement basse ou élevée pour l'inverter",
+              "alarm_code_7": "Baisse de la surchauffe de gaz de refoulement",
+              "alarm_code_8": "Température du gaz de refoulement excessive en haut du compresseur",
+              "alarm_code_11": "Anomalie de la thermistance de température d'arrivée de l'eau (THMWI)",
+              "alarm_code_12": "Anomalie de la thermistance de la température de sortie de l'eau (THMWO)",
+              "alarm_code_13": "Anomalie de la thermistance de température de la tuyauterie de liquide intérieure R410A (THML)",
+              "alarm_code_14": "Anomalie de la thermistance de température de la tuyauterie de gaz intérieure R410A (THMG)",
+              "alarm_code_15": "Anomalie de la thermistance de la température de sortie de l'eau du circuit 2 (THMWO2)",
+              "alarm_code_16": "Anomalie de la thermistance de la température de l'eau chaude sanitaire (THMDHW)",
+              "alarm_code_17": "Anomalie du capteur de température auxiliaire 2 (THMAUX2)",
+              "alarm_code_18": "Capteur universel",
+              "alarm_code_19": "Anomalie de la thermistance de la température",
+              "alarm_code_20": "Anomalie de la thermistance de la température du gaz de refoulement",
+              "alarm_code_21": "Anomalie de capteur haute pression",
+              "alarm_code_22": "Fonctionnement anormal de la thermistance de la température extérieure (THM7)",
+              "alarm_code_23": "Fonctionnement anormal de la thermistance du gaz de refoulement (THM9)",
+              "alarm_code_24": "Fonctionnement anormal de la thermistance de la température d'évaporation pendant le chauffage (THM8)",
+              "alarm_code_25": "Anomalie de la thermistance du capteur auxiliaire 3 (THMAUX3)",
+              "alarm_code_26": "Erreur de réglage de puissance ou de puissance combinée entre unité intérieure et groupe extérieur",
+              "alarm_code_35": "Erreur de réglage de puissance ou de puissance combinée entre unité intérieure et groupe extérieur",
+              "alarm_code_36": "Erreur de réglage de puissance ou de puissance combinée entre unité intérieure et groupe extérieur",
+              "alarm_code_38": "Anomalie du circuit de protection (groupe extérieur)",
+              "alarm_code_40": "Réglage incorrect du contrôleur d'unité",
+              "alarm_code_41": "Surcharge du pressostat de haute pression",
+              "alarm_code_42": "Surcharge en chauffage (le pressostat haute pression doit être activé)",
+              "alarm_code_45": "Activation de l'organe de protection contre l'augmentation de la haute pression",
+              "alarm_code_47": "Déclenchement de la protection du système contre une pression d'aspiration insuffisante",
+              "alarm_code_48": "Activation de la protection de surintensité",
+              "alarm_code_51": "Fonctionnement anormal de sonde d'intensité",
+              "alarm_code_53": "Activation du module de transistor",
+              "alarm_code_54": "Anomalie de température d'ailette de l'inverter",
+              "alarm_code_57": "Anomalie de la protection du moteur du ventilateur (moteur du ventilateur CC)",
+              "alarm_code_70": "Alarme du débit hydraulique et dysfonctionnement de la pompe à eau",
+              "alarm_code_72": "Alarme du thermostat du chauffe-eau",
+              "alarm_code_73": "Mélange de la protection de limite de température maxi. pour le circuit mixte",
+              "alarm_code_74": "Protection de limite de température de l'unité",
+              "alarm_code_75": "Protection antigel par détection de la température d'entrée/sortie d'eau froide",
+              "alarm_code_76": "Arrêt de la protection anti-gel par le thermistor de température des liquides intérieur",
+              "alarm_code_77": "Défaut de la communication du récepteur sans fil intelligent",
+              "alarm_code_78": "Défaut de la communication RF",
+              "alarm_code_79": "Réglage incorrect de la puissance",
+              "alarm_code_80": "Défaut de communication télécommande H-LINK",
+              "alarm_code_81": "Interruption momentanée de l'alimentation ou Basse tension détectée",
+              "alarm_code_83": "Anomalie de la basse pression dans le circuit hydraulique",
+              "alarm_code_101": "Commande d'activation du pressostat haute pression",
+              "alarm_code_102": "Activation du contrôle de la protection pour une excessive haute pression",
+              "alarm_code_104": "Activation du contrôle de la protection en raison d'une basse pression",
+              "alarm_code_105": "Différence de basse pression excessive",
+              "alarm_code_106": "Température du gaz de refoulement excessive",
+              "alarm_code_129": "Défaillance du capteur de pression du gaz de refoulement",
+              "alarm_code_130": "Défaillance du capteur de pression du gaz d'aspiration",
+              "alarm_code_132": "Erreur de transmission entre la PCB de l'inverter et la PCB principale",
+              "alarm_code_134": "Contrôle des anomalités de la phase de la source d'alimentation",
+              "alarm_code_135": "Réglage incorrect de PCB",
+              "alarm_code_151": "Contrôle des anomalies de tension de l'inverter",
+              "alarm_code_152": "Fonctionnement anormal de sonde d'intensité",
+              "alarm_code_153": "Activation de protection contre la surintensité de l'inverter (I)",
+              "alarm_code_154": "Activation de la protection du module de transistor",
+              "alarm_code_155": "Contrôle des anomalies de l'ailette de l'inverter",
+              "alarm_code_156": "Panne de l'inverter",
+              "alarm_code_157": "Autres anomalies",
+              "alarm_code_202": "Réglages incorrectes du contrôleur PC-ARF HE",
+              "alarm_code_203": "Arrêt de PC-ARFHE esclave en réponse au PC-ARFHE maître",
+              "alarm_code_204": "L'unité intérieure perd la communication avec le PC-ARFHE maître",
+              "alarm_code_205": "Alarme centrale, aucun message central"
+            }
+          }
+        }
+      },
+      "r134a_discharge_temp": {
+        "name": "Température de Refoulement R134a"
+      },
+      "r134a_suction_temp": {
+        "name": "Température d'Aspiration R134a"
+      },
+      "r134a_discharge_pressure": {
+        "name": "Pression de Refoulement R134a"
+      },
+      "r134a_suction_pressure": {
+        "name": "Pression d'Aspiration R134a"
+      },
+      "r134a_compressor_frequency": {
+        "name": "Fréquence du Compresseur R134a"
+      },
+      "r134a_compressor_current": {
+        "name": "Courant du Compresseur R134a"
+      }
+    },
+    "binary_sensor": {
+      "connectivity": {
+        "name": "Connectivité"
+      },
+      "defrost": {
+        "name": "Dégivrage"
+      },
+      "solar": {
+        "name": "Solaire"
+      },
+      "pump1": {
+        "name": "Pompe 1"
+      },
+      "pump2": {
+        "name": "Pompe 2"
+      },
+      "pump3": {
+        "name": "Pompe 3"
+      },
+      "compressor": {
+        "name": "Compresseur"
+      },
+      "boiler": {
+        "name": "Chaudière"
+      },
+      "dhw_heater": {
+        "name": "Chauffage ECS"
+      },
+      "space_heater": {
+        "name": "Chauffage d'Appoint"
+      },
+      "smart_function": {
+        "name": "Fonction Smart"
+      }
+    },
+    "select": {
+      "operation_mode_heat": {
+        "name": "Mode de Fonctionnement",
+        "state": {
+          "heat": "Chauffage",
+          "auto": "Auto"
+        }
+      },
+      "operation_mode_full": {
+        "name": "Mode de Fonctionnement",
+        "state": {
+          "cool": "Refroidissement",
+          "heat": "Chauffage",
+          "auto": "Auto"
+        }
+      },
+      "otc_calculation_method_heating": {
+        "name": "Méthode de Compensation Chauffage",
+        "state": {
+          "disabled": "Désactivé",
+          "points": "Points",
+          "gradient": "Gradient",
+          "fix": "Fixe"
+        }
+      },
+      "otc_calculation_method_cooling": {
+        "name": "Méthode de Compensation Refroidissement",
+        "state": {
+          "disabled": "Désactivé",
+          "points": "Points",
+          "fix": "Fixe"
+        }
+      }
+    },
+    "switch": {
+      "power": {
+        "name": "Alimentation"
+      },
+      "thermostat": {
+        "name": "Thermostat"
+      },
+      "eco_mode": {
+        "name": "Mode ECO"
+      },
+      "boost": {
+        "name": "Forçage ECS"
+      },
+      "high_demand": {
+        "name": "Demande intense"
+      },
+      "antilegionella": {
+        "name": "Anti-légionelle"
+      }
+    },
+    "number": {
+      "max_flow_temp_heating_otc": {
+        "name": "Température de départ maximum en chauffage"
+      },
+      "max_flow_temp_cooling_otc": {
+        "name": "Température de départ maximum en refroidissement"
+      },
+      "heat_eco_offset": {
+        "name": "Décalage ECO Chauffage"
+      },
+      "cool_eco_offset": {
+        "name": "Décalage ECO Refroidissement"
+      },
+      "current_temp": {
+        "name": "Température Ambiante"
+      },
+      "target_temp": {
+        "name": "Température Cible"
+      },
+      "dhw_current_temperature": {
+        "name": "Température Actuelle"
+      },
+      "dhw_target_temperature": {
+        "name": "Température Cible"
+      },
+      "pool_current_temperature": {
+        "name": "Température Actuelle"
+      },
+      "pool_target_temperature": {
+        "name": "Température Cible"
+      },
+      "antilegionella_temp": {
+        "name": "Température Anti-légionelle"
+      }
+    },
+    "climate": {
+      "climate": {
+        "name": "Contrôle Climatique",
+        "state": {
+          "off": "Arrêt",
+          "heat": "Chauffage",
+          "cool": "Refroidissement",
+          "auto": "Auto",
+          "idle": "Inactif",
+          "defrost": "Dégivrage"
+        },
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "eco": "Éco",
+              "comfort": "Confort"
+            }
+          }
+        }
+      },
+      "dhw_climate": {
+        "name": "Contrôle ECS",
+        "state": {
+          "off": "Arrêt",
+          "heat": "Chauffage"
+        },
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "dhw_off": "Arrêt",
+              "dhw_standard": "Standard",
+              "dhw_high_demand": "Haute Demande"
+            }
+          }
+        }
+      }
+    }
+  }
 }

--- a/custom_components/hitachi_yutaki/translations/fr.json
+++ b/custom_components/hitachi_yutaki/translations/fr.json
@@ -60,6 +60,23 @@
   },
   "entity": {
     "sensor": {
+      "operation_state": {
+        "name": "État de Fonctionnement",
+        "state": {
+          "operation_state_0": "Arrêt",
+          "operation_state_1": "Pas de demande refroidissement",
+          "operation_state_2": "Refroidissement Thermo OFF",
+          "operation_state_3": "Refroidissement Thermo ON",
+          "operation_state_4": "Pas de demande chauffage",
+          "operation_state_5": "Chauffage Thermo OFF",
+          "operation_state_6": "Chauffage Thermo ON",
+          "operation_state_7": "ECS OFF",
+          "operation_state_8": "ECS ON",
+          "operation_state_9": "Piscine OFF",
+          "operation_state_10": "Piscine ON",
+          "operation_state_11": "Alarme"
+        }
+      },
       "outdoor_temp": {
         "name": "Température Extérieure"
       },

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.4
+current_version = 1.4.0
 
 [flake8]
 exclude = .venv,.git,.tox,docs,venv,bin,lib,deps,build


### PR DESCRIPTION
# Add Compressor Cycle Time and Operation State Sensors

## Description
This PR adds two new diagnostic sensors:
1. A sensor that measures the average time between compressor starts
2. A sensor that shows the current operation state of the heat pump

These sensors provide valuable information for:
- Monitoring compressor cycling behavior and detecting short cycles
- Tracking the heat pump's current operating mode in detail
- Optimizing heat pump settings and troubleshooting

## Technical Details
### Compressor Cycle Time Sensor
- Calculates a moving average over the last 10 cycles
- Time is measured in minutes with one decimal place
- Uses existing `system_status` register and `MASK_COMPRESSOR` to detect starts

### Operation State Sensor
- Shows detailed operation state from register 1090
- Provides 12 different states (Off, Cooling, Heating, DHW, Pool, Alarm)
- Includes both demand and thermo states for heating/cooling

## Screenshots

![image](https://github.com/user-attachments/assets/a933757a-90eb-4dd9-ab0b-eb51fe350969)

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation improvement
- [ ] Code refactoring

## Checklist
- [x] Code follows project style conventions
- [x] Translations are complete (FR/EN)
- [x] Code has been tested locally
- [x] Documentation has been updated