### PR TITLE
feat: Disable not critical sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.2] - 2024-01-16
+
+### Changed
+- Optimized default sensor visibility based on configuration and relevance for standard users
+
 ## [1.5.1] - 2024-01-16
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-__VERSION__ = "1.5.1"
+__VERSION__ = "1.5.2"
 
 bump:
 	bump2version --allow-dirty --current-version $(__VERSION__) patch Makefile custom_components/hitachi_yutaki/const.py custom_components/hitachi_yutaki/manifest.json

--- a/custom_components/hitachi_yutaki/const.py
+++ b/custom_components/hitachi_yutaki/const.py
@@ -8,7 +8,7 @@ DOMAIN = "hitachi_yutaki"
 MANUFACTURER = "Hitachi"
 GATEWAY_MODEL = "ATW-MBS-02"
 
-VERSION = "1.5.1"
+VERSION = "1.5.2"
 
 # Default values
 DEFAULT_NAME = "Hitachi Yutaki"

--- a/custom_components/hitachi_yutaki/manifest.json
+++ b/custom_components/hitachi_yutaki/manifest.json
@@ -13,5 +13,5 @@
   "requirements": [
     "pymodbus>=3.6.9,<4.0.0"
   ],
-  "version": "1.5.1"
+  "version": "1.5.2"
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.5.1
+current_version = 1.5.2
 
 [flake8]
 exclude = .venv,.git,.tox,docs,venv,bin,lib,deps,build


### PR DESCRIPTION
## Description

This PR optimizes the default sensor visibility in the integration by:
- Showing sensors only for configured features (heating, cooling, DHW, pool)
- Focusing on the most relevant sensors for daily use
- Reducing visual clutter in the Home Assistant interface

## Changes

- Modified sensor entity registration to respect system configuration
- Adjusted default visibility of technical sensors
- Kept all sensors available but hidden by default when not commonly used

## Documentation

- Updated CHANGELOG.md with version 1.5.2