### PR TITLE
Thermal power sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.5.2] - 2024-01-16
+## [1.6.0] - 2025-02-06
+
+### Added
+- New thermal energy monitoring sensors:
+  - Real-time thermal power output (kW)
+  - Daily thermal energy production with midnight auto-reset (kWh)
+  - Total cumulative thermal energy production (kWh)
+- Detailed monitoring attributes:
+  - Temperature differential and water flow tracking
+  - Average power calculation over measurement periods
+  - Precise measurement timing with compressor state tracking
+- Full translations for all new features in French and English
+
+## [1.5.2] - 2025-01-16
 
 ### Changed
 - Optimized default sensor visibility based on configuration and relevance for standard users
 
-## [1.5.1] - 2024-01-16
+## [1.5.1] - 2025-01-16
 
 ### Fixed
 - Compatibility with latest pymodbus API
 
-## [1.5.0] - 2024-01-16
+## [1.5.0] - 2025-01-16
 
 ### Added
 - Improved logging for COP calculation and system state monitoring
@@ -24,7 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated pymodbus dependency to match Home Assistant's version
 - Optimized COP calculation parameters for better accuracy
 
-## [1.5.0-b7] - 2024-01-12
+## [1.5.0-b7] - 2025-01-12
 
 ### Added
 - Added quality indicators for COP measurements (no_data, insufficient_data, preliminary, optimal)
@@ -33,7 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed sample size and interval for more accurate COP calculation
 
-## [1.5.0-b6] - 2024-01-06
+## [1.5.0-b6] - 2025-01-06
 
 ### Fixed
 - Fixed COP calculation by applying water flow conversion (raw value was used instead of m³/h)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-__VERSION__ = "1.5.2"
+__VERSION__ = "1.6.0"
 
 bump:
 	bump2version --allow-dirty --current-version $(__VERSION__) patch Makefile custom_components/hitachi_yutaki/const.py custom_components/hitachi_yutaki/manifest.json

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ The integration automatically detects your heat pump model and available feature
 | compressor_current | sensor | Current electrical consumption of the compressor | A | diagnostic |
 | compressor_cycle_time | sensor | Average time between compressor starts | min | diagnostic |
 | power_consumption | sensor | Total electrical energy consumed by the unit | kWh | diagnostic |
+| thermal_power | sensor | Real-time thermal power output | kW | diagnostic |
+| daily_thermal_energy | sensor | Daily thermal energy production (resets at midnight) | kWh | diagnostic |
+| total_thermal_energy | sensor | Total cumulative thermal energy production | kWh | diagnostic |
 | cop_heating | sensor | Space heating COP calculated from water flow, temperatures and electrical consumption | - | diagnostic |
 | cop_cooling | sensor | Space cooling COP calculated from water flow, temperatures and electrical consumption | - | diagnostic |
 | cop_dhw | sensor | Domestic hot water COP calculated from water flow, temperatures and electrical consumption | - | diagnostic |
@@ -201,8 +204,8 @@ The integration automatically detects your heat pump model and available feature
     - Power supply type (single phase/three phase)
     - Voltage entity (optional - for real-time voltage measurements)
     - Power meter entity (optional - for real-time power measurements)
-    - Water inlet temperature entity (optional - for more accurate COP calculations)
-    - Water outlet temperature entity (optional - for more accurate COP calculations)
+    - Water inlet temperature entity (optional - for more accurate COP and thermal energy calculations)
+    - Water outlet temperature entity (optional - for more accurate COP and thermal energy calculations)
     - Advanced settings (optional):
         - Modbus slave ID (default: 1)
         - Scan interval (seconds)
@@ -244,6 +247,51 @@ Each COP sensor provides additional attributes:
 - `quality`: Current quality level of the measurement
 - `measurements`: Number of measurements used in calculation
 - `time_span_minutes`: Time span covered by the measurements
+
+## Thermal Energy Monitoring
+
+The integration provides detailed thermal energy monitoring through three complementary sensors:
+
+### Real-time Power Output
+
+The `thermal_power` sensor shows the instantaneous thermal power output in kW, calculated from:
+- Water flow rate
+- Temperature difference between outlet and inlet (ΔT)
+- Water specific heat capacity
+
+Additional attributes provide detailed measurement data:
+- `delta_t`: Temperature difference between outlet and inlet (°C)
+- `water_flow`: Current water flow rate (m³/h)
+- `last_update`: Timestamp of the last measurement
+
+### Daily Energy Production
+
+The `daily_thermal_energy` sensor tracks the thermal energy produced since midnight in kWh. It automatically resets at midnight and provides:
+- Automatic state restoration after Home Assistant restart (same day only)
+- Average power calculation over the measurement period
+- Detailed timing information in attributes:
+  - `last_reset`: Last midnight reset timestamp
+  - `start_time`: First measurement timestamp of the day
+  - `average_power`: Average power over the measurement period (kW)
+  - `time_span_hours`: Duration of the measurement period
+
+### Total Energy Production
+
+The `total_thermal_energy` sensor maintains a running total of all thermal energy produced in kWh. It features:
+- Persistent state across Home Assistant restarts
+- Long-term performance tracking
+- Statistical information in attributes:
+  - `start_date`: Date of the first measurement
+  - `average_power`: Average power since start (kW)
+  - `time_span_days`: Number of days since first measurement
+
+### Measurement Accuracy
+
+To ensure accuracy:
+- Measurements are only taken when the compressor is running
+- Calculations use precise water flow and temperature measurements
+- Values are stored with 2 decimal places precision
+- All relevant units are clearly indicated in attributes
 
 ## Development
 

--- a/custom_components/hitachi_yutaki/const.py
+++ b/custom_components/hitachi_yutaki/const.py
@@ -8,7 +8,7 @@ DOMAIN = "hitachi_yutaki"
 MANUFACTURER = "Hitachi"
 GATEWAY_MODEL = "ATW-MBS-02"
 
-VERSION = "1.5.2"
+VERSION = "1.6.0"
 
 # Default values
 DEFAULT_NAME = "Hitachi Yutaki"

--- a/custom_components/hitachi_yutaki/manifest.json
+++ b/custom_components/hitachi_yutaki/manifest.json
@@ -13,5 +13,5 @@
   "requirements": [
     "pymodbus>=3.6.9,<4.0.0"
   ],
-  "version": "1.5.2"
+  "version": "1.6.0"
 }

--- a/custom_components/hitachi_yutaki/translations/en.json
+++ b/custom_components/hitachi_yutaki/translations/en.json
@@ -368,6 +368,51 @@
       },
       "r134a_resttime": {
         "name": "R134a compressor rest time"
+      },
+      "thermal_power": {
+        "name": "Thermal Power",
+        "state_attributes": {
+          "last_update": {
+            "name": "Last Update"
+          },
+          "delta_t": {
+            "name": "Delta T"
+          },
+          "water_flow": {
+            "name": "Water Flow"
+          }
+        }
+      },
+      "daily_thermal_energy": {
+        "name": "Daily Thermal Energy",
+        "state_attributes": {
+          "last_reset": {
+            "name": "Last Reset"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "average_power": {
+            "name": "Average Power"
+          },
+          "time_span_hours": {
+            "name": "Measurement Period (hours)"
+          }
+        }
+      },
+      "total_thermal_energy": {
+        "name": "Total Thermal Energy",
+        "state_attributes": {
+          "start_date": {
+            "name": "Start Date"
+          },
+          "average_power": {
+            "name": "Average Power"
+          },
+          "time_span_days": {
+            "name": "Measurement Period (days)"
+          }
+        }
       }
     },
     "binary_sensor": {

--- a/custom_components/hitachi_yutaki/translations/fr.json
+++ b/custom_components/hitachi_yutaki/translations/fr.json
@@ -372,6 +372,51 @@
       },
       "r134a_resttime": {
         "name": "Temps de repos compresseur R134a"
+      },
+      "thermal_power": {
+        "name": "Puissance Thermique",
+        "state_attributes": {
+          "last_update": {
+            "name": "Dernière mise à jour"
+          },
+          "delta_t": {
+            "name": "Delta T"
+          },
+          "water_flow": {
+            "name": "Débit d'eau"
+          }
+        }
+      },
+      "daily_thermal_energy": {
+        "name": "Énergie Thermique Journalière",
+        "state_attributes": {
+          "last_reset": {
+            "name": "Dernière réinitialisation"
+          },
+          "start_time": {
+            "name": "Heure de début"
+          },
+          "average_power": {
+            "name": "Puissance moyenne"
+          },
+          "time_span_hours": {
+            "name": "Période de mesure (heures)"
+          }
+        }
+      },
+      "total_thermal_energy": {
+        "name": "Énergie Thermique Totale",
+        "state_attributes": {
+          "start_date": {
+            "name": "Date de début"
+          },
+          "average_power": {
+            "name": "Puissance moyenne"
+          },
+          "time_span_days": {
+            "name": "Période de mesure (jours)"
+          }
+        }
       }
     },
     "binary_sensor": {

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.5.2
+current_version = 1.6.0
 
 [flake8]
 exclude = .venv,.git,.tox,docs,venv,bin,lib,deps,build


### PR DESCRIPTION
# Add thermal energy sensors

This PR adds three new sensors to measure the heat pump's thermal energy production:

- `thermal_power`: Real-time thermal power output (kW)
- `daily_thermal_energy`: Daily thermal energy production (kWh, resets at midnight)
- `total_thermal_energy`: Total cumulative thermal energy production (kWh)

## Features

- Calculation based on water flow rate and temperature difference (ΔT)
- Measurements only when compressor is running
- State restoration after Home Assistant restart
- Detailed attributes for each sensor:
  - Measurement timestamps
  - Water flow and ΔT for instant power
  - Measurement period and average power for energy counters
  - Clearly indicated units

## Translations

Added French and English translations for all new sensors and their attributes.

## Documentation

Documentation has been updated to include:
- Description of new sensors
- Calculation method used
- Meaning of attributes