### PR TITLE
feat: DHW water heater platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.0] - 2025-03-19
+
+### Added
+- Implemented WaterHeaterEntity for Domestic Hot Water (DHW) control
+- Better integration with Home Assistant UI for water heater controls
+- Support for standard operation modes: off, standard, and high demand
+
 ## [1.6.1] - 2025-03-10
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-__VERSION__ = "1.6.1"
+__VERSION__ = "1.7.0"
 
 bump:
 	bump2version --allow-dirty --current-version $(__VERSION__) patch Makefile custom_components/hitachi_yutaki/const.py custom_components/hitachi_yutaki/manifest.json

--- a/README.md
+++ b/README.md
@@ -150,13 +150,22 @@ The integration automatically detects your heat pump model and available feature
 
 | Entity | Type | Description | Values/Unit |
 |--------|------|-------------|-------------|
+| dhw | water_heater | Main DHW control entity | - |
 | power | switch | Power switch for domestic hot water production | on/off |
 | boost | switch | Temporarily boost DHW production | on/off |
 | high_demand | switch | Enable high demand mode for increased DHW production | on/off |
-| target_temperature | number | Target temperature for domestic hot water | °C (30-80) |
+| target_temperature | number | Target temperature for domestic hot water | °C (30-60) |
 | current_temperature | sensor | Current DHW tank temperature | °C |
 | antilegionella | switch | Enable/disable periodic high temperature treatment | on/off |
 | antilegionella_temperature | number | Target temperature for anti-legionella treatment | °C (60-80) |
+
+The main DHW control entity (`water_heater`) provides:
+- Power control (on/off)
+- Operation modes (off, standard, high demand)
+- Temperature control (30-60°C)
+- Current temperature display
+
+Additional entities provide granular control over specific features.
 
 ### Swimming Pool Device (if configured)
 

--- a/custom_components/hitachi_yutaki/const.py
+++ b/custom_components/hitachi_yutaki/const.py
@@ -8,7 +8,7 @@ DOMAIN = "hitachi_yutaki"
 MANUFACTURER = "Hitachi"
 GATEWAY_MODEL = "ATW-MBS-02"
 
-VERSION = "1.6.1"
+VERSION = "1.7.0"
 
 # Default values
 DEFAULT_NAME = "Hitachi Yutaki"
@@ -144,6 +144,7 @@ PLATFORMS = [
     Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,
+    Platform.WATER_HEATER,
 ]
 
 MODEL_NAMES = {

--- a/custom_components/hitachi_yutaki/manifest.json
+++ b/custom_components/hitachi_yutaki/manifest.json
@@ -13,5 +13,5 @@
   "requirements": [
     "pymodbus>=3.6.9,<4.0.0"
   ],
-  "version": "1.6.1"
+  "version": "1.7.0"
 }

--- a/custom_components/hitachi_yutaki/number.py
+++ b/custom_components/hitachi_yutaki/number.py
@@ -148,6 +148,7 @@ DHW_NUMBERS: Final[tuple[HitachiYutakiNumberEntityDescription, ...]] = (
         register_key="target_temp",
         mode=NumberMode.BOX,
         entity_category=EntityCategory.CONFIG,
+        entity_registry_enabled_default=False,
     ),
     HitachiYutakiNumberEntityDescription(
         key="antilegionella_temp",

--- a/custom_components/hitachi_yutaki/sensor.py
+++ b/custom_components/hitachi_yutaki/sensor.py
@@ -295,6 +295,7 @@ DHW_SENSORS: Final[tuple[HitachiYutakiSensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         register_key="dhw_current_temp",
         value_fn=lambda value, coordinator: coordinator.convert_temperature(value),
+        entity_registry_enabled_default=False,
     ),
 )
 
@@ -1272,7 +1273,7 @@ class HitachiYutakiSensor(
                 self._daily_start_time = current_time
                 _LOGGER.debug(
                     "Initializing daily start time to %s",
-                    datetime.fromtimestamp(self._daily_start_time).isoformat(),
+                    datetime.fromtimestamp(self._daily_start_time).isoformat()
                 )
 
             # Calculate energy since last measurement

--- a/custom_components/hitachi_yutaki/switch.py
+++ b/custom_components/hitachi_yutaki/switch.py
@@ -92,6 +92,7 @@ DHW_SWITCHES: Final[tuple[HitachiYutakiSwitchEntityDescription, ...]] = (
         icon="mdi:power",
         description="Power switch for domestic hot water production",
         register_key="power",
+        entity_registry_enabled_default=False,
     ),
     HitachiYutakiSwitchEntityDescription(
         key="boost",

--- a/custom_components/hitachi_yutaki/translations/en.json
+++ b/custom_components/hitachi_yutaki/translations/en.json
@@ -564,21 +564,15 @@
             }
           }
         }
-      },
-      "dhw_climate": {
+      }
+    },
+    "water_heater": {
+      "dhw": {
         "name": "DHW Control",
         "state": {
           "off": "Off",
-          "heat": "Heat"
-        },
-        "state_attributes": {
-          "preset_mode": {
-            "state": {
-              "dhw_off": "Off",
-              "dhw_standard": "Standard",
-              "dhw_high_demand": "High Demand"
-            }
-          }
+          "standard": "Standard",
+          "high_demand": "High Demand"
         }
       }
     }

--- a/custom_components/hitachi_yutaki/translations/fr.json
+++ b/custom_components/hitachi_yutaki/translations/fr.json
@@ -339,22 +339,15 @@
         }
       },
       "cop_pool": {
-        "name": "COP Piscine",
+        "name": "Rendement Piscine (COP)",
         "state_attributes": {
           "quality": {
-            "name": "Qualité",
             "state": {
               "no_data": "Pas de données",
               "insufficient_data": "Données insuffisantes",
               "preliminary": "Préliminaire",
               "optimal": "Optimal"
             }
-          },
-          "measurements": {
-            "name": "Nombre de mesures"
-          },
-          "time_span_minutes": {
-            "name": "Période de mesure"
           }
         }
       },
@@ -568,21 +561,15 @@
             }
           }
         }
-      },
-      "dhw_climate": {
+      }
+    },
+    "water_heater": {
+      "dhw": {
         "name": "Contrôle ECS",
         "state": {
           "off": "Arrêt",
-          "heat": "Chauffage"
-        },
-        "state_attributes": {
-          "preset_mode": {
-            "state": {
-              "dhw_off": "Arrêt",
-              "dhw_standard": "Standard",
-              "dhw_high_demand": "Haute Demande"
-            }
-          }
+          "standard": "Standard",
+          "high_demand": "Haute Demande"
         }
       }
     }

--- a/custom_components/hitachi_yutaki/water_heater.py
+++ b/custom_components/hitachi_yutaki/water_heater.py
@@ -1,0 +1,202 @@
+"""Water heater platform for Hitachi Yutaki."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Final
+
+from homeassistant.components.water_heater import (
+    WaterHeaterEntity,
+    WaterHeaterEntityDescription,
+    WaterHeaterEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    ATTR_TEMPERATURE,
+    UnitOfTemperature,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import (
+    DEVICE_DHW,
+    DOMAIN,
+    PRESET_DHW_HIGH_DEMAND,
+    PRESET_DHW_OFF,
+    PRESET_DHW_STANDARD,
+)
+from .coordinator import HitachiYutakiDataCoordinator
+
+
+@dataclass
+class HitachiYutakiWaterHeaterEntityDescription(WaterHeaterEntityDescription):
+    """Class describing Hitachi Yutaki water heater entities."""
+
+    key: str
+    translation_key: str
+    description: str | None = None
+
+
+WATER_HEATERS: Final[tuple[HitachiYutakiWaterHeaterEntityDescription, ...]] = (
+    HitachiYutakiWaterHeaterEntityDescription(
+        key="dhw",
+        translation_key="dhw",
+        description="Domestic hot water production",
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the water heater."""
+    coordinator: HitachiYutakiDataCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    entities: list[HitachiYutakiWaterHeater] = []
+
+    # Add DHW water heater if configured
+    if coordinator.has_dhw():
+        entities.extend(
+            HitachiYutakiWaterHeater(
+                coordinator=coordinator,
+                description=description,
+                device_info=DeviceInfo(
+                    identifiers={(DOMAIN, f"{entry.entry_id}_{DEVICE_DHW}")},
+                ),
+            )
+            for description in WATER_HEATERS
+        )
+
+    async_add_entities(entities)
+
+
+class HitachiYutakiWaterHeater(
+    CoordinatorEntity[HitachiYutakiDataCoordinator], WaterHeaterEntity
+):
+    """Representation of a Hitachi Yutaki Water Heater."""
+
+    entity_description: HitachiYutakiWaterHeaterEntityDescription
+
+    def __init__(
+        self,
+        coordinator: HitachiYutakiDataCoordinator,
+        description: HitachiYutakiWaterHeaterEntityDescription,
+        device_info: DeviceInfo,
+    ) -> None:
+        """Initialize the water heater."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._register_prefix = "dhw"
+        entry_id = coordinator.config_entry.entry_id
+        self._attr_unique_id = f"{entry_id}_{coordinator.slave}_{description.key}"
+        self._attr_device_info = device_info
+        self._attr_has_entity_name = True
+        self._attr_temperature_unit = UnitOfTemperature.CELSIUS
+        self._attr_min_temp = 30
+        self._attr_max_temp = 60
+        self._attr_target_temperature_step = 1
+        self._attr_supported_features = (
+            WaterHeaterEntityFeature.TARGET_TEMPERATURE
+            | WaterHeaterEntityFeature.OPERATION_MODE
+            | WaterHeaterEntityFeature.ON_OFF
+        )
+        self._attr_operation_list = [
+            PRESET_DHW_OFF,
+            PRESET_DHW_STANDARD,
+            PRESET_DHW_HIGH_DEMAND,
+        ]
+
+    @property
+    def current_temperature(self) -> float | None:
+        """Return the current temperature."""
+        if self.coordinator.data is None:
+            return None
+
+        temp = self.coordinator.data.get("dhw_current_temp")
+        if temp is None:
+            return None
+
+        return float(self.coordinator.convert_temperature(temp))
+
+    @property
+    def target_temperature(self) -> float | None:
+        """Return the temperature we try to reach."""
+        if self.coordinator.data is None:
+            return None
+
+        temp = self.coordinator.data.get("dhw_target_temp")
+        if temp is None:
+            return None
+
+        return float(temp)
+
+    @property
+    def current_operation(self) -> str | None:
+        """Return current operation."""
+        if self.coordinator.data is None:
+            return None
+
+        power = self.coordinator.data.get("dhw_power")
+        if power == 0:
+            return PRESET_DHW_OFF
+
+        high_demand = self.coordinator.data.get("dhw_high_demand")
+        if high_demand == 1:
+            return PRESET_DHW_HIGH_DEMAND
+
+        return PRESET_DHW_STANDARD
+
+    @property
+    def icon(self) -> str:
+        """Return the icon to use in the frontend."""
+        operation = self.current_operation
+        if operation == PRESET_DHW_OFF:
+            return "mdi:water-boiler-off"
+        elif operation == PRESET_DHW_HIGH_DEMAND:
+            return "mdi:water-boiler-alert"
+        return "mdi:water-boiler"
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        """Set new target temperature."""
+        temperature = kwargs.get(ATTR_TEMPERATURE)
+        if temperature is None:
+            return
+
+        await self.coordinator.async_write_register(
+            "dhw_target_temp", int(temperature)
+        )
+
+    async def async_set_operation_mode(self, operation_mode: str) -> None:
+        """Set new operation mode."""
+        if operation_mode == PRESET_DHW_OFF:
+            # First disable high demand mode if it was active
+            await self.coordinator.async_write_register("dhw_high_demand", 0)
+            # Then turn off DHW
+            await self.coordinator.async_write_register("dhw_power", 0)
+            return
+
+        # First ensure DHW is turned on if it was off
+        current_power = self.coordinator.data.get("dhw_power", 0)
+        if current_power == 0:
+            await self.coordinator.async_write_register("dhw_power", 1)
+
+        # Then set the mode
+        if operation_mode == PRESET_DHW_HIGH_DEMAND:
+            await self.coordinator.async_write_register("dhw_high_demand", 1)
+        elif operation_mode == PRESET_DHW_STANDARD:
+            await self.coordinator.async_write_register("dhw_high_demand", 0)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the water heater on."""
+        await self.coordinator.async_write_register("dhw_power", 1)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the water heater off."""
+        # First disable high demand mode if it was active
+        await self.coordinator.async_write_register("dhw_high_demand", 0)
+        # Then turn off DHW
+        await self.coordinator.async_write_register("dhw_power", 0)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.6.1
+current_version = 1.7.0
 
 [flake8]
 exclude = .venv,.git,.tox,docs,venv,bin,lib,deps,build


### PR DESCRIPTION
Close #29 

## ✨ What's New

**Water Heater Platform:**
* New `water_heater` entity for unified DHW control
* Operation modes: Off, Standard, High Demand
* Temperature control (30-60°C)
* Automatic high demand mode management when switching to off

## 📝 Important Notes

**Entity Management:**
* Previous DHW entities are now disabled by default:
  - `dhw_power` switch
  - `dhw_high_demand` switch
  - `dhw_target_temperature` number
  - `dhw_current_temperature` sensor

These entities can be re-enabled in the entity settings if needed.

## Changes
- Added water_heater platform for DHW control
- Added turn_on/turn_off methods to water_heater entity
- Fixed temperature conversion in water_heater
- Disabled redundant DHW entities by default
- Updated documentation