### PR TITLE
feat: Allow usage of Water and Full control modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.0] - 2025-05-11
+
+### Changed
+- The integration now allows configuration with central control modes Air (1), Water (2), or Total (3). Only Local (0) is forbidden.
+- Error messages and documentation updated to reflect this change.
+- The documentation now recommends using Air (1) mode for most installations.
+
 ## [1.7.1] - 2025-03-27
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-__VERSION__ = "1.7.1"
+__VERSION__ = "1.8.0"
 
 bump:
 	bump2version --allow-dirty --current-version $(__VERSION__) patch Makefile custom_components/hitachi_yutaki/const.py custom_components/hitachi_yutaki/manifest.json

--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ Additional entities provide granular control over specific features.
 
 ## Configuration
 
+> **Note:** The heat pump's central control mode must NOT be set to 'Local' (0). Accepted modes are: Air (1), Water (2), or Total (3). **The 'Air' (1) mode is recommended for most installations.** Please check this setting in your heat pump parameters (System Configuration > General Options > External Control Option > Control Mode).
+
 1. Go to Settings -> Devices & Services
 2. Click "Add Integration"
 3. Search for "Hitachi Yutaki"

--- a/custom_components/hitachi_yutaki/config_flow.py
+++ b/custom_components/hitachi_yutaki/config_flow.py
@@ -261,7 +261,7 @@ class HitachiYutakiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         errors=errors,
                     )
 
-                if mode_result.registers[0] != CENTRAL_CONTROL_MODE_MAP["air"]:
+                if mode_result.registers[0] == CENTRAL_CONTROL_MODE_MAP["local"]:
                     errors["base"] = "invalid_central_control_mode"
                     return self.async_show_form(
                         step_id="advanced" if "show_advanced" in config else "user",

--- a/custom_components/hitachi_yutaki/const.py
+++ b/custom_components/hitachi_yutaki/const.py
@@ -8,7 +8,7 @@ DOMAIN = "hitachi_yutaki"
 MANUFACTURER = "Hitachi"
 GATEWAY_MODEL = "ATW-MBS-02"
 
-VERSION = "1.7.1"
+VERSION = "1.8.0"
 
 # Default values
 DEFAULT_NAME = "Hitachi Yutaki"

--- a/custom_components/hitachi_yutaki/manifest.json
+++ b/custom_components/hitachi_yutaki/manifest.json
@@ -13,5 +13,5 @@
   "requirements": [
     "pymodbus>=3.6.9,<4.0.0"
   ],
-  "version": "1.7.1"
+  "version": "1.8.0"
 }

--- a/custom_components/hitachi_yutaki/translations/en.json
+++ b/custom_components/hitachi_yutaki/translations/en.json
@@ -100,7 +100,7 @@
       "invalid_slave": "Invalid Modbus slave ID",
       "modbus_error": "Modbus communication error",
       "unknown": "Unexpected error",
-      "invalid_central_control_mode": "The heat pump must be configured in Central mode 'Air' (1). Possible modes: Local (0), Air (1), Water (2), Total (3). Please change this setting in your heat pump parameters. (System Configuration > General Options > External Control Option > Control Mode = Air)"
+      "invalid_central_control_mode": "The heat pump must not be configured in Local mode (0). Possible modes: Air (1), Water (2), Total (3). Please change this setting in your heat pump parameters (System Configuration > General Options > External Control Option > Control Mode)."
     },
     "abort": {
       "already_configured": "Device is already configured"

--- a/custom_components/hitachi_yutaki/translations/fr.json
+++ b/custom_components/hitachi_yutaki/translations/fr.json
@@ -104,7 +104,7 @@
       "invalid_slave": "ID esclave Modbus invalide",
       "modbus_error": "Erreur de communication Modbus",
       "unknown": "Erreur inattendue",
-      "invalid_central_control_mode": "La pompe à chaleur doit être configurée en mode Central 'Air' (1). Modes possibles : Local (0), Air (1), Water (2), Total (3). Veuillez modifier ce réglage dans les paramètres de votre pompe à chaleur (Configuration du système > Options générales > Option commande externe > Mode de controle = Air)."
+      "invalid_central_control_mode": "La pompe à chaleur ne doit pas être configurée en mode Local (0). Modes possibles : Air (1), Water (2), Total (3). Veuillez modifier ce réglage dans les paramètres de votre pompe à chaleur (Configuration du système > Options générales > Option commande externe > Mode de controle)."
     },
     "abort": {
       "already_configured": "L'appareil est déjà configuré"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.7.1
+current_version = 1.8.0
 
 [flake8]
 exclude = .venv,.git,.tox,docs,venv,bin,lib,deps,build


### PR DESCRIPTION
## Allow configuration with all central control modes except "Local" (0)

### Description

This PR updates the Hitachi Yutaki integration to allow installation and configuration when the heat pump's central control mode is set to any value except "Local" (0). Previously, only the "Air" (1) mode was accepted. Now, the integration will accept "Air" (1), "Water" (2), or "Total" (3) modes, and will only block configuration if the mode is set to "Local" (0).

### Key changes

- The configuration flow now checks that the central control mode is **not** "Local" (0), instead of requiring "Air" (1).
- Error messages and documentation have been updated to reflect this change.
- The README now includes a clear note that "Air" (1) mode is recommended for most installations, but "Water" (2) and "Total" (3) are also supported.
- French and English translations for the error message have been updated accordingly.
- Changelog updated for version 1.8.0.

### Motivation

Some installations require the use of "Full" (Total) or "Water" central control modes. This change improves compatibility and user experience by allowing these modes, while still preventing misconfiguration with the unsupported "Local" mode.