### PR TITLE
feat: Add anti-legionella cycle functionality and remove redundant DH…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.1] - 2025-05-12
+
+### Added
+- New "Anti-legionella Cycle" button entity to manually start a high temperature anti-legionella treatment cycle.
+- New binary sensor entity (`antilegionella_cycle`) indicating if an anti-legionella cycle is currently running.
+
+### Changed
+- Removed unused or redundant Domestic Hot Water (DHW) entities: DHW current temperature sensor, DHW target temperature number, DHW power switch, high demand switch, and periodic anti-legionella switch.
+- Improved English and French translations for new entities and advanced configuration (water inlet/outlet temperature entities).
+
 ## [1.8.0] - 2025-05-11
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-__VERSION__ = "1.8.0"
+__VERSION__ = "1.8.1"
 
 bump:
 	bump2version --allow-dirty --current-version $(__VERSION__) patch Makefile custom_components/hitachi_yutaki/const.py custom_components/hitachi_yutaki/manifest.json

--- a/README.md
+++ b/README.md
@@ -146,13 +146,10 @@ The integration automatically detects your heat pump model and available feature
 | Entity | Type | Description | Values/Unit |
 |--------|------|-------------|-------------|
 | dhw | water_heater | Main DHW control entity | - |
-| power | switch | Power switch for domestic hot water production | on/off |
 | boost | switch | Temporarily boost DHW production | on/off |
-| high_demand | switch | Enable high demand mode for increased DHW production | on/off |
-| target_temperature | number | Target temperature for domestic hot water | °C (30-60) |
-| current_temperature | sensor | Current DHW tank temperature | °C |
-| antilegionella | switch | Enable/disable periodic high temperature treatment | on/off |
 | antilegionella_temperature | number | Target temperature for anti-legionella treatment | °C (60-80) |
+| antilegionella_cycle | binary_sensor | Indicates if an anti-legionella cycle is currently running | on/off |
+| antilegionella | button | Manually start a high temperature anti-legionella treatment cycle | - |
 
 The main DHW control entity (`water_heater`) provides:
 - Power control (on/off)

--- a/custom_components/hitachi_yutaki/button.py
+++ b/custom_components/hitachi_yutaki/button.py
@@ -1,0 +1,115 @@
+"""Button platform for Hitachi Yutaki."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+from homeassistant.components.button import (
+    ButtonEntity,
+    ButtonEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import (
+    DEVICE_DHW,
+    DOMAIN,
+)
+from .coordinator import HitachiYutakiDataCoordinator
+
+
+@dataclass
+class HitachiYutakiButtonEntityDescription(ButtonEntityDescription):
+    """Class describing Hitachi Yutaki button entities."""
+
+    key: str
+    translation_key: str
+    icon: str | None = None
+    entity_category: EntityCategory | None = None
+    entity_registry_enabled_default: bool = True
+    entity_registry_visible_default: bool = True
+    register_key: str | None = None
+    description: str | None = None
+
+
+DHW_BUTTONS: Final[tuple[HitachiYutakiButtonEntityDescription, ...]] = (
+    HitachiYutakiButtonEntityDescription(
+        key="antilegionella",
+        translation_key="antilegionella",
+        icon="mdi:biohazard",
+        description="Start a high temperature anti-legionella treatment cycle. Once started, the cycle cannot be stopped.",
+        register_key="antilegionella",
+        entity_registry_enabled_default=True,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the button entities."""
+    coordinator: HitachiYutakiDataCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    entities: list[HitachiYutakiButton] = []
+
+    # Add DHW buttons if configured
+    if coordinator.has_dhw():
+        entities.extend(
+            HitachiYutakiButton(
+                coordinator=coordinator,
+                description=description,
+                device_info=DeviceInfo(
+                    identifiers={(DOMAIN, f"{entry.entry_id}_{DEVICE_DHW}")},
+                ),
+                register_prefix="dhw",
+            )
+            for description in DHW_BUTTONS
+        )
+
+    async_add_entities(entities)
+
+
+class HitachiYutakiButton(
+    CoordinatorEntity[HitachiYutakiDataCoordinator], ButtonEntity
+):
+    """Representation of a Hitachi Yutaki Button."""
+
+    entity_description: HitachiYutakiButtonEntityDescription
+
+    def __init__(
+        self,
+        coordinator: HitachiYutakiDataCoordinator,
+        description: HitachiYutakiButtonEntityDescription,
+        device_info: DeviceInfo,
+        register_prefix: str | None = None,
+    ) -> None:
+        """Initialize the button."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self.register_prefix = register_prefix
+        self._register_key = (
+            f"{register_prefix}_{description.register_key}"
+            if register_prefix
+            else description.register_key
+        )
+        entry_id = coordinator.config_entry.entry_id
+        self._attr_unique_id = (
+            f"{entry_id}_{coordinator.slave}_{register_prefix}_{description.key}"
+            if register_prefix
+            else f"{entry_id}_{coordinator.slave}_{description.key}"
+        )
+        self._attr_device_info = device_info
+        self._attr_has_entity_name = True
+
+    async def async_press(self) -> None:
+        """Handle the button press."""
+        if self._register_key is None:
+            return
+        await self.coordinator.async_write_register(self._register_key, 1)

--- a/custom_components/hitachi_yutaki/const.py
+++ b/custom_components/hitachi_yutaki/const.py
@@ -8,7 +8,7 @@ DOMAIN = "hitachi_yutaki"
 MANUFACTURER = "Hitachi"
 GATEWAY_MODEL = "ATW-MBS-02"
 
-VERSION = "1.8.0"
+VERSION = "1.8.1"
 
 # Default values
 DEFAULT_NAME = "Hitachi Yutaki"
@@ -123,6 +123,7 @@ REGISTER_SENSOR = {
     "compressor_current": 1214,
     "power_consumption": 1098,
     "alarm_code": 1223,
+    "dhw_antilegionella_status": 1030,
 }
 
 # R134a specific registers (S80 only)
@@ -145,6 +146,7 @@ PLATFORMS = [
     Platform.SENSOR,
     Platform.SWITCH,
     Platform.WATER_HEATER,
+    Platform.BUTTON,
 ]
 
 MODEL_NAMES = {

--- a/custom_components/hitachi_yutaki/manifest.json
+++ b/custom_components/hitachi_yutaki/manifest.json
@@ -10,8 +10,18 @@
   "homekit": {},
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/alepee/hass-hitachi_yutaki/issues",
+  "platforms": [
+    "switch",
+    "sensor",
+    "number",
+    "select",
+    "climate",
+    "binary_sensor",
+    "water_heater",
+    "button"
+  ],
   "requirements": [
     "pymodbus>=3.6.9,<4.0.0"
   ],
-  "version": "1.8.0"
+  "version": "1.8.1"
 }

--- a/custom_components/hitachi_yutaki/manifest.json
+++ b/custom_components/hitachi_yutaki/manifest.json
@@ -10,16 +10,6 @@
   "homekit": {},
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/alepee/hass-hitachi_yutaki/issues",
-  "platforms": [
-    "switch",
-    "sensor",
-    "number",
-    "select",
-    "climate",
-    "binary_sensor",
-    "water_heater",
-    "button"
-  ],
   "requirements": [
     "pymodbus>=3.6.9,<4.0.0"
   ],

--- a/custom_components/hitachi_yutaki/number.py
+++ b/custom_components/hitachi_yutaki/number.py
@@ -138,19 +138,6 @@ CIRCUIT_NUMBERS: Final[tuple[HitachiYutakiNumberEntityDescription, ...]] = (
 
 DHW_NUMBERS: Final[tuple[HitachiYutakiNumberEntityDescription, ...]] = (
     HitachiYutakiNumberEntityDescription(
-        key="target_temp",
-        translation_key="dhw_target_temperature",
-        description="Target temperature for domestic hot water",
-        native_min_value=30,
-        native_max_value=60,
-        native_step=1,
-        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        register_key="target_temp",
-        mode=NumberMode.BOX,
-        entity_category=EntityCategory.CONFIG,
-        entity_registry_enabled_default=False,
-    ),
-    HitachiYutakiNumberEntityDescription(
         key="antilegionella_temp",
         translation_key="antilegionella_temp",
         description="Target temperature for anti-legionella treatment",

--- a/custom_components/hitachi_yutaki/sensor.py
+++ b/custom_components/hitachi_yutaki/sensor.py
@@ -286,19 +286,7 @@ TEMPERATURE_SENSORS: Final[tuple[HitachiYutakiSensorEntityDescription, ...]] = (
     ),
 )
 
-DHW_SENSORS: Final[tuple[HitachiYutakiSensorEntityDescription, ...]] = (
-    HitachiYutakiSensorEntityDescription(
-        key="dhw_current_temp",
-        translation_key="dhw_current_temperature",
-        description="Current temperature of the domestic hot water",
-        device_class=SensorDeviceClass.TEMPERATURE,
-        state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        register_key="dhw_current_temp",
-        value_fn=lambda value, coordinator: coordinator.convert_temperature(value),
-        entity_registry_enabled_default=False,
-    ),
-)
+DHW_SENSORS: Final[tuple[HitachiYutakiSensorEntityDescription, ...]] = ()
 
 POOL_SENSORS: Final[tuple[HitachiYutakiSensorEntityDescription, ...]] = (
     HitachiYutakiSensorEntityDescription(

--- a/custom_components/hitachi_yutaki/switch.py
+++ b/custom_components/hitachi_yutaki/switch.py
@@ -61,13 +61,6 @@ UNIT_SWITCHES: Final[tuple[HitachiYutakiSwitchEntityDescription, ...]] = (
 
 CIRCUIT_SWITCHES: Final[tuple[HitachiYutakiSwitchEntityDescription, ...]] = (
     HitachiYutakiSwitchEntityDescription(
-        key="power",
-        translation_key="power",
-        icon="mdi:power",
-        description="Power switch for this heating/cooling circuit",
-        register_key="power",
-    ),
-    HitachiYutakiSwitchEntityDescription(
         key="thermostat",
         translation_key="thermostat",
         description="Enable/disable the Modbus thermostat function for this circuit",
@@ -87,34 +80,10 @@ CIRCUIT_SWITCHES: Final[tuple[HitachiYutakiSwitchEntityDescription, ...]] = (
 
 DHW_SWITCHES: Final[tuple[HitachiYutakiSwitchEntityDescription, ...]] = (
     HitachiYutakiSwitchEntityDescription(
-        key="power",
-        translation_key="power",
-        icon="mdi:power",
-        description="Power switch for domestic hot water production",
-        register_key="power",
-        entity_registry_enabled_default=False,
-    ),
-    HitachiYutakiSwitchEntityDescription(
         key="boost",
         translation_key="boost",
         description="Temporarily boost DHW production",
         register_key="boost",
-    ),
-    HitachiYutakiSwitchEntityDescription(
-        key="high_demand",
-        translation_key="high_demand",
-        icon="mdi:crowd",
-        description="Enable high demand mode for increased DHW production",
-        register_key="high_demand",
-        entity_registry_enabled_default=False,
-    ),
-    HitachiYutakiSwitchEntityDescription(
-        key="antilegionella",
-        translation_key="antilegionella",
-        description="Enable/disable periodic high temperature treatment to prevent legionella",
-        register_key="antilegionella",
-        entity_category=EntityCategory.CONFIG,
-        entity_registry_enabled_default=False,
     ),
 )
 

--- a/custom_components/hitachi_yutaki/translations/en.json
+++ b/custom_components/hitachi_yutaki/translations/en.json
@@ -460,8 +460,7 @@
         "name": "R134a compressor running"
       },
       "antilegionella_cycle": {
-        "name": "Anti-legionella cycle",
-        "description": "Indicates if an anti-legionella cycle is currently running"
+        "name": "Anti-legionella cycle"
       }
     },
     "select": {
@@ -517,8 +516,7 @@
     },
     "button": {
       "antilegionella": {
-        "name": "Start Anti-legionella Cycle",
-        "description": "Start a high temperature anti-legionella treatment cycle. Once started, the cycle cannot be stopped."
+        "name": "Start Anti-legionella Cycle"
       }
     },
     "number": {

--- a/custom_components/hitachi_yutaki/translations/en.json
+++ b/custom_components/hitachi_yutaki/translations/en.json
@@ -41,11 +41,15 @@
           "host": "Gateway IP address",
           "port": "Gateway port",
           "voltage_entity": "Voltage entity (optional)",
-          "power_entity": "Power entity (optional)"
+          "power_entity": "Power entity (optional)",
+          "water_inlet_temp_entity": "Water inlet temperature entity (optional)",
+          "water_outlet_temp_entity": "Water outlet temperature entity (optional)"
         },
         "data_description": {
           "voltage_entity": "Entity providing real-time voltage measurements. If not set, default values will be used",
-          "power_entity": "Entity providing real-time power consumption measurements. If not set, power will be calculated"
+          "power_entity": "Entity providing real-time power consumption measurements. If not set, power will be calculated",
+          "water_inlet_temp_entity": "Entity providing more precise water inlet temperature measurements. If not set, internal measurements will be used",
+          "water_outlet_temp_entity": "Entity providing more precise water outlet temperature measurements. If not set, internal measurements will be used"
         },
         "description": "Modify your Hitachi Yutaki heat pump settings"
       }
@@ -454,6 +458,10 @@
       },
       "r134a_compressor_running": {
         "name": "R134a compressor running"
+      },
+      "antilegionella_cycle": {
+        "name": "Anti-legionella cycle",
+        "description": "Indicates if an anti-legionella cycle is currently running"
       }
     },
     "select": {
@@ -505,9 +513,12 @@
       },
       "high_demand": {
         "name": "High Demand"
-      },
+      }
+    },
+    "button": {
       "antilegionella": {
-        "name": "Anti-legionella"
+        "name": "Start Anti-legionella Cycle",
+        "description": "Start a high temperature anti-legionella treatment cycle. Once started, the cycle cannot be stopped."
       }
     },
     "number": {
@@ -527,12 +538,6 @@
         "name": "Current Temperature"
       },
       "target_temp": {
-        "name": "Target Temperature"
-      },
-      "dhw_current_temperature": {
-        "name": "Current Temperature"
-      },
-      "dhw_target_temperature": {
         "name": "Target Temperature"
       },
       "pool_current_temperature": {

--- a/custom_components/hitachi_yutaki/translations/fr.json
+++ b/custom_components/hitachi_yutaki/translations/fr.json
@@ -460,8 +460,7 @@
         "name": "Compresseur R134a en marche"
       },
       "antilegionella_cycle": {
-        "name": "Cycle anti-légionelle",
-        "description": "Indique si un cycle anti-légionelle est en cours"
+        "name": "Cycle anti-légionelle"
       }
     },
     "select": {
@@ -514,8 +513,7 @@
     },
     "button": {
       "antilegionella": {
-        "name": "Démarrer le cycle anti-légionelle",
-        "description": "Démarre un cycle de traitement anti-légionelle à haute température. Une fois démarré, le cycle ne peut pas être arrêté."
+        "name": "Démarrer le cycle anti-légionelle"
       }
     },
     "number": {

--- a/custom_components/hitachi_yutaki/translations/fr.json
+++ b/custom_components/hitachi_yutaki/translations/fr.json
@@ -342,12 +342,19 @@
         "name": "Rendement Piscine (COP)",
         "state_attributes": {
           "quality": {
+            "name": "Qualité",
             "state": {
               "no_data": "Pas de données",
               "insufficient_data": "Données insuffisantes",
               "preliminary": "Préliminaire",
               "optimal": "Optimal"
             }
+          },
+          "measurements": {
+            "name": "Nombre de mesures"
+          },
+          "time_span_minutes": {
+            "name": "Période de mesure"
           }
         }
       },
@@ -451,6 +458,10 @@
       },
       "r134a_compressor_running": {
         "name": "Compresseur R134a en marche"
+      },
+      "antilegionella_cycle": {
+        "name": "Cycle anti-légionelle",
+        "description": "Indique si un cycle anti-légionelle est en cours"
       }
     },
     "select": {
@@ -499,12 +510,12 @@
       },
       "boost": {
         "name": "Forçage ECS"
-      },
-      "high_demand": {
-        "name": "Demande intense"
-      },
+      }
+    },
+    "button": {
       "antilegionella": {
-        "name": "Anti-légionelle"
+        "name": "Démarrer le cycle anti-légionelle",
+        "description": "Démarre un cycle de traitement anti-légionelle à haute température. Une fois démarré, le cycle ne peut pas être arrêté."
       }
     },
     "number": {
@@ -524,12 +535,6 @@
         "name": "Température Ambiante"
       },
       "target_temp": {
-        "name": "Température Cible"
-      },
-      "dhw_current_temperature": {
-        "name": "Température Actuelle"
-      },
-      "dhw_target_temperature": {
         "name": "Température Cible"
       },
       "pool_current_temperature": {

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.8.0
+current_version = 1.8.1
 
 [flake8]
 exclude = .venv,.git,.tox,docs,venv,bin,lib,deps,build


### PR DESCRIPTION
### Entities update: Domestic Hot Water (DHW)

This PR refactors the Domestic Hot Water (DHW) entities to simplify and clarify their usage:

**Removed entities:**
- DHW power switch
- DHW high demand switch
- Periodic anti-legionella switch
- DHW target temperature number
- DHW current temperature sensor

**Added entities:**
- `antilegionella_cycle` (binary_sensor): Indicates if an anti-legionella cycle is currently running.
- `antilegionella` (button): Allows manual start of a high temperature anti-legionella treatment cycle.

**Notes:**
- All main DHW controls (power, operation mode, target temperature, current temperature) are now handled via the `water_heater` entity.
- The new button and binary sensor provide improved monitoring and manual control for anti-legionella cycles.

These changes streamline the DHW experience, reduce redundancy, and improve clarity for end users.