### PR TITLE
fix: Add repository to HACS button

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This custom integration allows you to control and monitor your Hitachi **Yutaki** and **Yutampo** air-to-water heat pumps through Home Assistant using a Modbus ATW-MBS-02 gateway.
 
-[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=alepee&repository=hass-hitachi_yutaki)
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)]([https://my.home-assistant.io/redirect/hacs_repository/?owner=alepee&repository=hass-hitachi_yutaki](https://my.home-assistant.io/redirect/hacs_repository/?owner=alepee&repository=hass-hitachi_yutaki&category=integration))
 
 ## Compatibility
 


### PR DESCRIPTION
This Pull Request updates the HACS badge link in the `README.md` file to include the `category=integration` parameter in the URL.

### ✅ Changes Made

* Adjusted the HACS redirect link to include the `category=integration` query parameter.
* This change ensures that users are redirected more precisely to the integration section of the Home Assistant Community Store, improving the user experience when adding the integration.

### 🔗 Before / After Comparison

**Before:**

```md
https://my.home-assistant.io/redirect/hacs_repository/?owner=alepee&repository=hass-hitachi_yutaki
```

**After:**

```md
https://my.home-assistant.io/redirect/hacs_repository/?owner=alepee&repository=hass-hitachi_yutaki&category=integration
```

### 🧪 Testing

* [x] Manually verified that the updated link redirects correctly to the integration page in HACS.