### PR TITLE
feat: Handle offline startup gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.0] - 2025-07-07
+
+### Added
+- New sensor to monitor the gateway's synchronization state (`Synchronized`, `Desynchronized`, `Initializing`).
+- Pre-flight check during setup and updates to verify gateway synchronization status. This creates a persistent notification ("Repair") if the gateway is desynchronized, guiding the user to resolve the issue.
+
+### Changed
+- Improved startup resilience. The integration now caches the heat pump's configuration during the first successful setup. This ensures that all devices and entities are registered during subsequent Home Assistant startups, even if the heat pump is temporarily offline.
+
+### Fixed
+- Resolved a critical issue where all integration entities would disappear if the heat pump was offline when Home Assistant started. Entities will now appear as `unavailable` until the connection is restored.
+
 ## [1.8.2] - 2025-06-26
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-__VERSION__ = "1.8.2"
+__VERSION__ = "1.9.0"
 
 bump:
 	bump2version --allow-dirty --current-version $(__VERSION__) patch Makefile custom_components/hitachi_yutaki/const.py custom_components/hitachi_yutaki/manifest.json

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ This custom integration allows you to control and monitor your Hitachi **Yutaki*
 
 The integration provides:
 - Automatic model detection and configuration
+- Resilient to gateway connection issues at startup
+- Gateway synchronization status monitoring with automated repair suggestions
 - Multi-language support (English, French)
 - Real-time performance monitoring (COP calculation)
 - Comprehensive alarm descriptions with translations
@@ -43,6 +45,7 @@ The integration automatically detects your heat pump model and available feature
 | Entity | Type | Description | Unit |
 |--------|------|-------------|------|
 | connectivity | binary_sensor | Indicates if the gateway is connected and responding | - |
+| sync_state   | sensor        | Indicates the gateway synchronization state with the heat pump | - |
 
 ### Heat Pump Control Unit Device
 

--- a/custom_components/hitachi_yutaki/const.py
+++ b/custom_components/hitachi_yutaki/const.py
@@ -8,7 +8,7 @@ DOMAIN = "hitachi_yutaki"
 MANUFACTURER = "Hitachi"
 GATEWAY_MODEL = "ATW-MBS-02"
 
-VERSION = "1.8.2"
+VERSION = "1.9.0"
 
 # Default values
 DEFAULT_NAME = "Hitachi Yutaki"

--- a/custom_components/hitachi_yutaki/const.py
+++ b/custom_components/hitachi_yutaki/const.py
@@ -33,6 +33,7 @@ REGISTER_UNIT_MODEL = 1218
 REGISTER_CENTRAL_CONTROL_MODE = 1088
 REGISTER_SYSTEM_CONFIG = 1089
 REGISTER_SYSTEM_STATUS = 1222
+REGISTER_SYSTEM_STATE = 1094
 
 # Unit models
 UNIT_MODEL_YUTAKI_S = 0
@@ -136,6 +137,8 @@ REGISTER_R134A = {
     "r134a_valve_opening": 1229,
     "r134a_compressor_current": 1230,
     "r134a_retry_code": 1231,
+    "r134a_hp_pressure": 1150,
+    "r134a_lp_pressure": 1151,
 }
 
 PLATFORMS = [
@@ -179,6 +182,13 @@ PRESET_ECO = "eco"
 PRESET_DHW_OFF = "off"
 PRESET_DHW_HEAT_PUMP = "heat_pump"
 PRESET_DHW_HIGH_DEMAND = "high_demand"
+
+# System state values
+SYSTEM_STATE_MAP = {
+    0: "synchronized",
+    1: "desynchronized",
+    2: "initializing",
+}
 
 # Operation state values
 OPERATION_STATE_MAP = {

--- a/custom_components/hitachi_yutaki/manifest.json
+++ b/custom_components/hitachi_yutaki/manifest.json
@@ -13,5 +13,5 @@
   "requirements": [
     "pymodbus>=3.6.9,<4.0.0"
   ],
-  "version": "1.8.2"
+  "version": "1.9.0"
 }

--- a/custom_components/hitachi_yutaki/translations/en.json
+++ b/custom_components/hitachi_yutaki/translations/en.json
@@ -36,78 +36,64 @@
   "options": {
     "step": {
       "init": {
+        "title": "Hitachi Yutaki Options",
+        "description": "Update your Hitachi Yutaki configuration.",
         "data": {
-          "power_supply": "Power supply",
-          "host": "Gateway IP address",
-          "port": "Gateway port",
-          "voltage_entity": "Voltage entity (optional)",
-          "power_entity": "Power entity (optional)",
-          "water_inlet_temp_entity": "Water inlet temperature entity (optional)",
-          "water_outlet_temp_entity": "Water outlet temperature entity (optional)"
-        },
-        "data_description": {
-          "voltage_entity": "Entity providing real-time voltage measurements. If not set, default values will be used",
-          "power_entity": "Entity providing real-time power consumption measurements. If not set, power will be calculated",
-          "water_inlet_temp_entity": "Entity providing more precise water inlet temperature measurements. If not set, internal measurements will be used",
-          "water_outlet_temp_entity": "Entity providing more precise water outlet temperature measurements. If not set, internal measurements will be used"
-        },
-        "description": "Modify your Hitachi Yutaki heat pump settings"
+          "host": "Host/IP Address",
+          "port": "Port",
+          "power_supply": "Power Supply",
+          "voltage_entity": "Voltage Sensor (Optional)",
+          "power_entity": "Power Sensor (Optional)",
+          "water_inlet_temp_entity": "Water Inlet Temperature Sensor (Optional)",
+          "water_outlet_temp_entity": "Water Outlet Temperature Sensor (Optional)"
+        }
       }
     }
   },
   "config": {
     "step": {
       "user": {
+        "title": "Hitachi Yutaki Gateway",
+        "description": "Enter the connection details for your Hitachi Yutaki heat pump gateway.",
         "data": {
           "name": "Name",
-          "host": "Gateway IP address",
-          "port": "Gateway port",
-          "show_advanced": "Show advanced settings"
-        },
-        "data_description": {
-          "host": "IP address of the ATW-MBS-02 gateway",
-          "port": "Modbus TCP communication port (default: 502)"
-        },
-        "description": "Configure your Hitachi Yutaki heat pump via the Modbus TCP/IP interface exposed by the ATW-MBS-02 gateway.",
-        "title": "Gateway Configuration"
+          "host": "Host/IP Address",
+          "port": "Port",
+          "show_advanced": "Show advanced options"
+        }
       },
       "power": {
+        "title": "Power Configuration",
+        "description": "Configure power and external temperature sensors.",
         "data": {
-          "power_supply": "Power supply",
-          "voltage_entity": "Voltage entity (optional)",
-          "power_entity": "Power entity (optional)",
-          "water_inlet_temp_entity": "Water inlet temperature entity (optional)",
-          "water_outlet_temp_entity": "Water outlet temperature entity (optional)"
-        },
-        "data_description": {
-          "power_supply": "Type of power supply for the heat pump",
-          "voltage_entity": "Entity providing the mains voltage measurements. If not set, default values will be used",
-          "power_entity": "Entity providing real-time power consumption measurements. If not set, power will be calculated",
-          "water_inlet_temp_entity": "Entity providing more precise water inlet temperature measurements. If not set, internal measurements will be used",
-          "water_outlet_temp_entity": "Entity providing more precise water outlet temperature measurements. If not set, internal measurements will be used"
-        },
-        "description": "Power supply configuration",
-        "title": "Power Supply"
+          "power_supply": "Power Supply",
+          "voltage_entity": "Voltage Sensor (Optional)",
+          "power_entity": "Power Sensor (Optional)",
+          "water_inlet_temp_entity": "Water Inlet Temperature Sensor (Optional)",
+          "water_outlet_temp_entity": "Water Outlet Temperature Sensor (Optional)"
+        }
       },
       "advanced": {
+        "title": "Advanced Settings",
+        "description": "Configure advanced Modbus and integration settings.",
         "data": {
-          "slave": "Modbus slave ID",
-          "scan_interval": "Scan interval (seconds)",
-          "dev_mode": "Developer mode"
-        },
-        "description": "Advanced settings are intended for developers and users with custom Modbus configurations.",
-        "title": "Advanced Settings"
+          "slave": "Modbus Slave ID",
+          "scan_interval": "Polling Interval (seconds)",
+          "dev_mode": "Development Mode (enables all entities)"
+        }
       }
     },
     "error": {
-      "cannot_connect": "Failed to connect",
-      "invalid_slave": "Invalid Modbus slave ID",
-      "modbus_error": "Modbus communication error",
-      "unknown": "Unexpected error",
-      "invalid_central_control_mode": "The heat pump must not be configured in Local mode (0). Possible modes: Air (1), Water (2), Total (3). Please change this setting in your heat pump parameters (System Configuration > General Options > External Control Option > Control Mode)."
+      "cannot_connect": "Failed to connect to the gateway. Please check the host and port.",
+      "invalid_slave": "Invalid Modbus slave ID. Please check the ID and try again.",
+      "modbus_error": "A Modbus error occurred. Check the logs for more details.",
+      "invalid_central_control_mode": "The gateway must be in 'Central' control mode. Please change it in the gateway settings.",
+      "unknown": "An unknown error occurred. Please check the logs.",
+      "system_initializing": "The Hitachi Yutaki gateway is initializing. Please wait a moment and try again.",
+      "desync_error": "The gateway is out of sync with the heat pump. Ensure the heat pump is powered on and the connection between the two devices is correct."
     },
     "abort": {
-      "already_configured": "Device is already configured"
+      "already_configured": "This Hitachi Yutaki gateway is already configured."
     }
   },
   "entity": {
@@ -417,6 +403,14 @@
             "name": "Measurement Period (days)"
           }
         }
+      },
+      "system_state": {
+        "name": "Gateway Sync State",
+        "state": {
+          "synchronized": "Synchronized",
+          "desynchronized": "Desynchronized",
+          "initializing": "Initializing"
+        }
       }
     },
     "binary_sensor": {
@@ -578,6 +572,16 @@
           "high_demand": "High Demand"
         }
       }
+    }
+  },
+  "issues": {
+    "desync_warning": {
+      "title": "Hitachi Gateway Desynchronized",
+      "description": "The Hitachi gateway has lost synchronization with the heat pump for over 3 minutes. The entities will be unavailable until the connection is restored.\n\n**To resolve this:**\n1. Check the physical connection between the gateway and the heat pump.\n2. Ensure the heat pump is powered on.\n3. Restart the heat pump and the gateway if the issue persists."
+    },
+    "connection_error": {
+      "title": "Hitachi Gateway Unreachable",
+      "description": "The integration could not connect to the Hitachi Yutaki gateway. The entities will be unavailable until the connection is restored.\n\n**To resolve this:**\n1. Check if the gateway is powered on and connected to the network.\n2. Verify that the IP address and port configured in Home Assistant are correct."
     }
   }
 }

--- a/custom_components/hitachi_yutaki/translations/fr.json
+++ b/custom_components/hitachi_yutaki/translations/fr.json
@@ -36,78 +36,64 @@
   "options": {
     "step": {
       "init": {
+        "title": "Options Hitachi Yutaki",
+        "description": "Mettez à jour votre configuration Hitachi Yutaki.",
         "data": {
+          "host": "Hôte/Adresse IP",
+          "port": "Port",
           "power_supply": "Alimentation électrique",
-          "host": "Adresse IP de la passerelle",
-          "port": "Port de la passerelle",
-          "voltage_entity": "Entité de tension (optionnel)",
-          "power_entity": "Entité de puissance (optionnel)",
-          "water_inlet_temp_entity": "Entité de température d'entrée d'eau (optionnel)",
-          "water_outlet_temp_entity": "Entité de température de sortie d'eau (optionnel)"
-        },
-        "data_description": {
-          "voltage_entity": "Entité fournissant la tension en temps réel. Si non définie, les valeurs par défaut seront utilisées",
-          "power_entity": "Entité fournissant la puissance consommée en temps réel. Si non définie, la puissance sera calculée",
-          "water_inlet_temp_entity": "Entité fournissant une mesure plus précise de la température d'entrée d'eau. Si non définie, les mesures internes seront utilisées",
-          "water_outlet_temp_entity": "Entité fournissant une mesure plus précise de la température de sortie d'eau. Si non définie, les mesures internes seront utilisées"
-        },
-        "description": "Modifiez les paramètres de votre pompe à chaleur Hitachi Yutaki"
+          "voltage_entity": "Capteur de tension (Optionnel)",
+          "power_entity": "Capteur de puissance (Optionnel)",
+          "water_inlet_temp_entity": "Capteur de température d'entrée d'eau (Optionnel)",
+          "water_outlet_temp_entity": "Capteur de température de sortie d'eau (Optionnel)"
+        }
       }
     }
   },
   "config": {
     "step": {
       "user": {
+        "title": "Passerelle Hitachi Yutaki",
+        "description": "Entrez les détails de connexion pour votre passerelle de pompe à chaleur Hitachi Yutaki.",
         "data": {
           "name": "Nom",
-          "host": "Adresse IP de la passerelle",
-          "port": "Port de la passerelle",
-          "show_advanced": "Afficher les paramètres avancés"
-        },
-        "data_description": {
-          "host": "Adresse IP de la passerelle ATW-MBS-02",
-          "port": "Port de communication Modbus TCP (par défaut: 502)"
-        },
-        "description": "Configurez votre pompe à chaleur Hitachi Yutaki via l'interface Modbus TCP/IP exposée par la passerelle ATW-MBS-02.",
-        "title": "Configuration de la passerelle"
+          "host": "Hôte/Adresse IP",
+          "port": "Port",
+          "show_advanced": "Afficher les options avancées"
+        }
       },
       "power": {
+        "title": "Configuration de l'alimentation",
+        "description": "Configurez l'alimentation et les capteurs de température externes.",
         "data": {
           "power_supply": "Alimentation électrique",
-          "voltage_entity": "Entité de tension (optionnel)",
-          "power_entity": "Entité de puissance (optionnel)",
-          "water_inlet_temp_entity": "Entité de température d'entrée d'eau (optionnel)",
-          "water_outlet_temp_entity": "Entité de température de sortie d'eau (optionnel)"
-        },
-        "data_description": {
-          "power_supply": "Type d'alimentation électrique de la pompe à chaleur",
-          "voltage_entity": "Entité fournissant la tension du réseau électrique. Si non définie, les valeurs par défaut seront utilisées",
-          "power_entity": "Entité fournissant la puissance consommée en temps réel. Si non définie, la puissance sera calculée",
-          "water_inlet_temp_entity": "Entité fournissant une mesure plus précise de la température d'entrée d'eau. Si non définie, les mesures internes seront utilisées",
-          "water_outlet_temp_entity": "Entité fournissant une mesure plus précise de la température de sortie d'eau. Si non définie, les mesures internes seront utilisées"
-        },
-        "description": "Configuration de l'alimentation électrique",
-        "title": "Alimentation électrique"
+          "voltage_entity": "Capteur de tension (Optionnel)",
+          "power_entity": "Capteur de puissance (Optionnel)",
+          "water_inlet_temp_entity": "Capteur de température d'entrée d'eau (Optionnel)",
+          "water_outlet_temp_entity": "Capteur de température de sortie d'eau (Optionnel)"
+        }
       },
       "advanced": {
+        "title": "Paramètres avancés",
+        "description": "Configurez les paramètres avancés de Modbus et de l'intégration.",
         "data": {
-          "slave": "ID esclave Modbus",
-          "scan_interval": "Intervalle de scan (secondes)",
-          "dev_mode": "Mode développeur"
-        },
-        "description": "Les paramètres avancés sont destinés aux développeurs et aux utilisateurs ayant une configuration Modbus personnalisée.",
-        "title": "Paramètres avancés"
+          "slave": "ID Esclave Modbus",
+          "scan_interval": "Intervalle d'interrogation (secondes)",
+          "dev_mode": "Mode développeur (active toutes les entités)"
+        }
       }
     },
     "error": {
-      "cannot_connect": "Échec de connexion",
-      "invalid_slave": "ID esclave Modbus invalide",
-      "modbus_error": "Erreur de communication Modbus",
-      "unknown": "Erreur inattendue",
-      "invalid_central_control_mode": "La pompe à chaleur ne doit pas être configurée en mode Local (0). Modes possibles : Air (1), Water (2), Total (3). Veuillez modifier ce réglage dans les paramètres de votre pompe à chaleur (Configuration du système > Options générales > Option commande externe > Mode de controle)."
+      "cannot_connect": "Échec de la connexion à la passerelle. Veuillez vérifier l'hôte et le port.",
+      "invalid_slave": "ID d'esclave Modbus invalide. Veuillez vérifier l'ID et réessayer.",
+      "modbus_error": "Une erreur Modbus s'est produite. Consultez les journaux pour plus de détails.",
+      "invalid_central_control_mode": "La passerelle doit être en mode de contrôle 'Central'. Veuillez modifier ce paramètre dans les réglages de la passerelle.",
+      "unknown": "Une erreur inconnue s'est produite. Veuillez consulter les journaux.",
+      "system_initializing": "La passerelle Hitachi Yutaki est en cours d'initialisation. Veuillez patienter quelques instants et réessayer.",
+      "desync_error": "La passerelle est désynchronisée de la pompe à chaleur. Assurez-vous que la pompe à chaleur est sous tension et que la connexion entre les deux appareils est correcte."
     },
     "abort": {
-      "already_configured": "L'appareil est déjà configuré"
+      "already_configured": "Cette passerelle Hitachi Yutaki est déjà configurée."
     }
   },
   "entity": {
@@ -417,6 +403,14 @@
             "name": "Période de mesure (jours)"
           }
         }
+      },
+      "system_state": {
+        "name": "État de synchronisation de la passerelle",
+        "state": {
+          "synchronized": "Synchronisé",
+          "desynchronized": "Désynchronisé",
+          "initializing": "Initialisation"
+        }
       }
     },
     "binary_sensor": {
@@ -575,6 +569,16 @@
           "high_demand": "Haute Demande"
         }
       }
+    }
+  },
+  "issues": {
+    "desync_warning": {
+      "title": "Passerelle Hitachi Désynchronisée",
+      "description": "La passerelle Hitachi a perdu la synchronisation avec la pompe à chaleur pendant plus de 3 minutes. Les entités seront indisponibles jusqu'à ce que la connexion soit rétablie.\n\n**Pour résoudre ce problème :**\n1. Vérifiez la connexion physique entre la passerelle et la pompe à chaleur.\n2. Assurez-vous que la pompe à chaleur est sous tension.\n3. Redémarrez la pompe à chaleur et la passerelle si le problème persiste."
+    },
+    "connection_error": {
+      "title": "Passerelle Hitachi Inaccessible",
+      "description": "L'intégration n'a pas pu se connecter à la passerelle Hitachi Yutaki. Les entités seront indisponibles jusqu'à ce que la connexion soit rétablie.\n\n**Pour résoudre ce problème :**\n1. Vérifiez si la passerelle est sous tension et connectée au réseau.\n2. Vérifiez que l'adresse IP et le port configurés dans Home Assistant sont corrects."
     }
   }
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.8.2
+current_version = 1.9.0
 
 [flake8]
 exclude = .venv,.git,.tox,docs,venv,bin,lib,deps,build


### PR DESCRIPTION
This Pull Request significantly improves the robustness, reliability, and user experience of the integration. It addresses the critical issue of entities disappearing when the heat pump is offline during startup and introduces new diagnostic tools to better inform the user about the system's status.

### Solved Issue

Fixes #67: The integration no longer raises an error, and entities are no longer removed if the heat pump is unreachable during Home Assistant startup.

### Summary of Changes

#### 1. Startup Resilience & Offline Device Handling
The most significant change in this PR is the integration's ability to handle an offline heat pump (HP) at startup.
-   **Configuration Caching**: During the first successful setup, the HP model and its system configuration (registers `unit_model` and `system_config`) are now stored in the `ConfigEntry`.
-   **Failure-Tolerant Initialization**: On Home Assistant startup, if the HP is unreachable, the integration uses this cached data to register all devices and entities. They will now appear as `unavailable` instead of disappearing, preventing user confusion. The integration will then attempt to reconnect in the background.

#### 2. System State Pre-flight Check
To provide faster and more accurate feedback, a system synchronization state check (register `1094`) has been added at two key moments:
-   **During Setup**: If a user tries to add the integration while the gateway is desynchronized (`state=1`) or initializing (`state=2`), a clear and specific error message is now displayed, guiding them on the next steps.
-   **During Updates**: In each data refresh cycle, this state is checked first. If the gateway is desynchronized or initializing, the update for other entities is paused to avoid reporting incorrect data.

#### 3. Home Assistant Repairs Framework Integration
To improve the visibility of issues, the integration now leverages the "Repairs" dashboard:
-   A **persistent repair notification** is created if the gateway loses synchronization with the HP, or if the connection to the gateway is lost.
-   This notification provides the user with steps to diagnose and resolve the problem.
-   The repair issue is **automatically cleared** as soon as the connection is restored and the system becomes synchronized again.

#### 4. New Sensor: Gateway Sync State
A new diagnostic sensor has been added to the "Gateway" device:
-   **Name**: `Gateway Sync State`
-   **Possible States**:
    -   `Synchronized`
    -   `Desynchronized`
    -   `Initializing`
-   The sensor's icon dynamically changes (`mdi:sync`, `mdi:sync-off`, `mdi:sync-alert`) to reflect the current state, offering a quick and intuitive visual cue.

### How to Test

1.  **Test Offline Startup**:
    -   Ensure the integration is configured and working correctly.
    -   Power off your heat pump or disconnect the gateway from the network.
    -   Restart Home Assistant.
    -   **Expected**: All Hitachi Yutaki entities should appear, but with an `unavailable` state. No "entity has been removed" warnings should be visible.
    -   Reconnect the gateway. The entities should return to their normal state after a few moments.

2.  **Test State Sensor and Repairs** (if you can simulate a desynchronization):
    -   Disconnect the communication cable between the gateway and the HP (if possible) for over 3 minutes.
    -   **Expected**: The `Gateway Sync State` sensor should change to "Desynchronized". A repair notification should appear in the Home Assistant "Repairs" dashboard.
    -   Reconnect the cable. The sensor should switch back to "Synchronized," and the repair notification should be cleared automatically.