### PR TITLE
Gracefully handle connectivity loss to Modbus gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Improved error handling in the data update coordinator to consistently create a repair issue in Home Assistant for any Modbus or network communication error.
+
 ### Fixed
 - Resolved an issue where a loss of IP connectivity to the Modbus gateway could cause the integration to crash or behave unexpectedly. The integration now correctly handles network errors (`OSError`), ensuring that all entities become `unavailable` and properly recover once the connection is restored. ([#76](https://github.com/alepee/hass-hitachi_yutaki/issues/76))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Resolved an issue where a loss of IP connectivity to the Modbus gateway could cause the integration to crash or behave unexpectedly. The integration now correctly handles network errors (`OSError`), ensuring that all entities become `unavailable` and properly recover once the connection is restored. ([#76](https://github.com/alepee/hass-hitachi_yutaki/issues/76))
+
 ## [1.9.0] - 2025-07-07
 
 ### Added

--- a/custom_components/hitachi_yutaki/binary_sensor.py
+++ b/custom_components/hitachi_yutaki/binary_sensor.py
@@ -336,6 +336,7 @@ class HitachiYutakiBinarySensor(
         if (
             self.coordinator.data is None
             or self.entity_description.register_key is None
+            or not self.coordinator.last_update_success
         ):
             return None
 
@@ -352,3 +353,8 @@ class HitachiYutakiBinarySensor(
             return bool(value & self.entity_description.mask)
 
         return None
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self.coordinator.last_update_success

--- a/custom_components/hitachi_yutaki/button.py
+++ b/custom_components/hitachi_yutaki/button.py
@@ -108,6 +108,11 @@ class HitachiYutakiButton(
         self._attr_device_info = device_info
         self._attr_has_entity_name = True
 
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self.coordinator.last_update_success
+
     async def async_press(self) -> None:
         """Handle the button press."""
         if self._register_key is None:

--- a/custom_components/hitachi_yutaki/climate.py
+++ b/custom_components/hitachi_yutaki/climate.py
@@ -149,6 +149,11 @@ class HitachiYutakiClimate(
         self._attr_preset_modes = [PRESET_COMFORT, PRESET_ECO]
 
     @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self.coordinator.last_update_success
+
+    @property
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
         if self.coordinator.data is None:
@@ -195,12 +200,11 @@ class HitachiYutakiClimate(
     @property
     def hvac_action(self) -> HVACAction | None:
         """Return the current running hvac operation."""
+        if self.hvac_mode == HVACAction.OFF:
+            return HVACAction.OFF
+
         if self.coordinator.data is None:
             return None
-
-        power = self.coordinator.data.get(f"{self._register_prefix}_power")
-        if power == 0:
-            return HVACAction.OFF
 
         system_status = self.coordinator.data.get("system_status", 0)
 

--- a/custom_components/hitachi_yutaki/number.py
+++ b/custom_components/hitachi_yutaki/number.py
@@ -276,6 +276,11 @@ class HitachiYutakiNumber(
         self._attr_has_entity_name = True
 
     @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self.coordinator.last_update_success
+
+    @property
     def native_value(self) -> float | None:
         """Return the entity value to represent the entity state."""
         if self.coordinator.data is None or self._register_key is None:

--- a/custom_components/hitachi_yutaki/select.py
+++ b/custom_components/hitachi_yutaki/select.py
@@ -192,6 +192,11 @@ class HitachiYutakiSelect(
         self._attr_has_entity_name = True
 
     @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self.coordinator.last_update_success
+
+    @property
     def current_option(self) -> str | None:
         """Return the selected entity option to represent the entity state."""
         if (

--- a/custom_components/hitachi_yutaki/switch.py
+++ b/custom_components/hitachi_yutaki/switch.py
@@ -221,6 +221,11 @@ class HitachiYutakiSwitch(
         self._attr_has_entity_name = True
 
     @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self.coordinator.last_update_success
+
+    @property
     def is_on(self) -> bool | None:
         """Return true if the switch is on."""
         if self.coordinator.data is None or self._register_key is None:
@@ -273,12 +278,5 @@ class HitachiYutakiSwitch(
                 "Failed to turn off %s: invalid value %s - Error: %s",
                 self.entity_id,
                 self.entity_description.state_off,
-                str(e),
-            )
-        except Exception as e:
-            _LOGGER.error(
-                "Unexpected error turning off %s: %s - %s",
-                self.entity_id,
-                type(e).__name__,
                 str(e),
             )

--- a/custom_components/hitachi_yutaki/water_heater.py
+++ b/custom_components/hitachi_yutaki/water_heater.py
@@ -111,6 +111,11 @@ class HitachiYutakiWaterHeater(
         ]
 
     @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self.coordinator.last_update_success
+
+    @property
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
         if self.coordinator.data is None:


### PR DESCRIPTION
This pull request resolves issue [#76](https://github.com/alepee/hass-hitachi_yutaki/issues/76) by significantly improving how the integration handles network connectivity loss to the Hitachi Yutaki Modbus gateway.

#### The Problem

As reported by @mrtnkhl, if the IP connection to the gateway was lost, an unhandled `OSError` would occur during the data update process. This had several negative consequences:
-   The update coordinator would fail silently without properly notifying Home Assistant.
-   Entities would not become `unavailable` in the UI, instead showing stale or no data.
-   No user-facing notification was created to alert them of the problem.
-   Subsequent errors, like `AttributeError: 'NoneType' object has no attribute 'get'`, would appear in the logs as the code tried to access data that was never fetched.

#### The Solution

This PR implements a comprehensive fix to make the integration more resilient and user-friendly when network issues arise.

1.  **Robust Coordinator Error Handling (`coordinator.py`)**
    -   The `_async_update_data` method now has a centralized exception handler for all communication-related issues (`ModbusException`, `ConnectionError`, and `OSError`).
    -   When any of these errors are caught, the coordinator now:
        -   Raises `UpdateFailed`, which is the standard Home Assistant mechanism to signal that an update has failed.
        -   Creates a repair issue via `issue_registry.async_create_issue`, providing a persistent and visible notification to the user in the "Repairs" section of the UI.
    -   This repair issue is automatically cleared as soon as a subsequent data update succeeds.

2.  **Consistent Entity Availability (All Platforms)**
    -   An explicit `@property def available(self)` has been added to all entity classes (`sensor`, `binary_sensor`, `climate`, `switch`, `button`, `number`, `select`, `water_heater`).
    -   This property is tied directly to `coordinator.last_update_success`, ensuring that all entities reliably reflect the true connection state.

3.  **Code Hardening**
    -   Added `if self.coordinator.data is None:` checks in entity code to prevent `AttributeError` exceptions in cases where data is unavailable after a failed update.
    -   Refactored and cleaned up minor exception handling inconsistencies in other parts of the code for better reliability.

#### Impact on Users

-   **Clear Status:** Users will now see all integration entities correctly become `unavailable` if the connection is lost.
-   **Proactive Notifications:** Users will be immediately notified of connectivity problems via the Home Assistant "Repairs" dashboard.
-   **Increased Stability:** The integration will no longer crash or fill logs with confusing errors due to network problems.
-   **Automatic Recovery:** Everything returns to normal automatically once the connection is restored, including the dismissal of the repair notification.

These changes ensure that the integration's behavior is now predictable, robust, and aligned with Home Assistant's best practices for handling device availability.

**Closes #76**