### PR TITLE
pymodbus compatibility with Home Assistant 2025.9.0+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.2] - 2025-09-05
+
+### Fixed
+- Fixed pymodbus compatibility issue with Home Assistant 2025.9.0+ by implementing automatic version detection for the device/slave parameter. The integration now works with both pymodbus < 3.10.0 (using `slave` parameter) and pymodbus >= 3.10.0 (using `device_id` parameter), ensuring compatibility across all Home Assistant versions. ([#97](https://github.com/alepee/hass-hitachi_yutaki/issues/97))
+
 ## [1.9.1] - 2025-07-22
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-__VERSION__ = "1.9.1"
+__VERSION__ = "1.9.2"
 
 bump:
 	bump2version --allow-dirty --current-version $(__VERSION__) patch Makefile custom_components/hitachi_yutaki/const.py custom_components/hitachi_yutaki/manifest.json

--- a/custom_components/hitachi_yutaki/config_flow.py
+++ b/custom_components/hitachi_yutaki/config_flow.py
@@ -40,6 +40,7 @@ from .const import (
     REGISTER_SYSTEM_CONFIG,
     REGISTER_SYSTEM_STATE,
     REGISTER_UNIT_MODEL,
+    get_pymodbus_device_param,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -225,11 +226,12 @@ class HitachiYutakiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             try:
                 # Preflight check for system state
+                device_param = get_pymodbus_device_param()
                 preflight_result = await self.hass.async_add_executor_job(
                     lambda addr=REGISTER_SYSTEM_STATE: client.read_holding_registers(
                         address=addr,
                         count=1,
-                        slave=config[CONF_SLAVE],
+                        **{device_param: config[CONF_SLAVE]},
                     )
                 )
 
@@ -270,7 +272,7 @@ class HitachiYutakiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     lambda addr=REGISTER_UNIT_MODEL: client.read_holding_registers(
                         address=addr,
                         count=1,
-                        slave=config[CONF_SLAVE],
+                        **{device_param: config[CONF_SLAVE]},
                     )
                 )
 
@@ -291,7 +293,7 @@ class HitachiYutakiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     lambda addr=REGISTER_CENTRAL_CONTROL_MODE: client.read_holding_registers(
                         address=addr,
                         count=1,
-                        slave=config[CONF_SLAVE],
+                        **{device_param: config[CONF_SLAVE]},
                     )
                 )
 
@@ -320,7 +322,7 @@ class HitachiYutakiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     lambda addr=REGISTER_SYSTEM_CONFIG: client.read_holding_registers(
                         address=addr,
                         count=1,
-                        slave=config[CONF_SLAVE],
+                        **{device_param: config[CONF_SLAVE]},
                     )
                 )
 

--- a/custom_components/hitachi_yutaki/const.py
+++ b/custom_components/hitachi_yutaki/const.py
@@ -3,6 +3,7 @@
 from datetime import timedelta
 
 from packaging import version
+import pymodbus
 
 from homeassistant.const import Platform
 
@@ -247,8 +248,6 @@ def get_pymodbus_device_param():
 
     """
     try:
-        import pymodbus  # noqa: PLC0415
-
         pymodbus_version = version.parse(pymodbus.__version__)
         if pymodbus_version >= version.parse("3.10.0"):
             return "device_id"

--- a/custom_components/hitachi_yutaki/const.py
+++ b/custom_components/hitachi_yutaki/const.py
@@ -2,13 +2,15 @@
 
 from datetime import timedelta
 
+from packaging import version
+
 from homeassistant.const import Platform
 
 DOMAIN = "hitachi_yutaki"
 MANUFACTURER = "Hitachi"
 GATEWAY_MODEL = "ATW-MBS-02"
 
-VERSION = "1.9.1"
+VERSION = "1.9.2"
 
 # Default values
 DEFAULT_NAME = "Hitachi Yutaki"
@@ -235,3 +237,23 @@ COP_MIN_MEASUREMENTS = 6  # Minimum number of measurements for COP calculation
 COP_MIN_TIME_SPAN = 3  # Minimum time span in minutes for COP calculation
 COP_OPTIMAL_MEASUREMENTS = 10  # Number of measurements for optimal COP calculation
 COP_OPTIMAL_TIME_SPAN = 15  # Time span in minutes for optimal COP calculation
+
+
+def get_pymodbus_device_param():
+    """Get the correct parameter name for pymodbus device/slave based on version.
+
+    Returns:
+        str: 'device_id' for pymodbus >= 3.10.0, 'slave' for older versions
+
+    """
+    try:
+        import pymodbus  # noqa: PLC0415
+
+        pymodbus_version = version.parse(pymodbus.__version__)
+        if pymodbus_version >= version.parse("3.10.0"):
+            return "device_id"
+        else:
+            return "slave"
+    except (ImportError, AttributeError):
+        # Fallback to 'slave' if pymodbus is not available or version cannot be determined
+        return "slave"

--- a/custom_components/hitachi_yutaki/coordinator.py
+++ b/custom_components/hitachi_yutaki/coordinator.py
@@ -70,10 +70,6 @@ class HitachiYutakiDataCoordinator(DataUpdateCoordinator):
             update_interval=timedelta(seconds=entry.data[CONF_SCAN_INTERVAL]),
         )
 
-    def _get_device_param(self) -> str:
-        """Get the correct parameter name for pymodbus device/slave based on version."""
-        return get_pymodbus_device_param()
-
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from Hitachi Yutaki."""
         try:
@@ -83,7 +79,7 @@ class HitachiYutakiDataCoordinator(DataUpdateCoordinator):
             data: dict[str, Any] = {"is_available": True}
 
             # Preflight check
-            device_param = self._get_device_param()
+            device_param = get_pymodbus_device_param()
             preflight_result = await self.hass.async_add_executor_job(
                 lambda addr=REGISTER_SYSTEM_STATE: self.modbus_client.read_holding_registers(
                     address=addr,
@@ -219,7 +215,7 @@ class HitachiYutakiDataCoordinator(DataUpdateCoordinator):
                 register_address,
             )
 
-            device_param = self._get_device_param()
+            device_param = get_pymodbus_device_param()
             result = await self.hass.async_add_executor_job(
                 lambda addr=register_address,
                 val=value: self.modbus_client.write_register(

--- a/custom_components/hitachi_yutaki/manifest.json
+++ b/custom_components/hitachi_yutaki/manifest.json
@@ -13,5 +13,5 @@
   "requirements": [
     "pymodbus>=3.6.9,<4.0.0"
   ],
-  "version": "1.9.1"
+  "version": "1.9.2"
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.9.1
+current_version = 1.9.2
 
 [flake8]
 exclude = .venv,.git,.tox,docs,venv,bin,lib,deps,build


### PR DESCRIPTION
Fixes compatibility issue with Home Assistant 2025.9.0+ which uses pymodbus 3.11. Since pymodbus version 3.10.0, the `slave` parameter was renamed to `device_id` in the API, causing errors for users of HA 2025.9.0+.

### Problem

- **HA 2025.8 and earlier**: Uses pymodbus < 3.10.0 → parameter `slave=`
- **HA 2025.9.0+**: Uses pymodbus 3.10.0+ → parameter `device_id=`

### Solution Implemented

Implementation of automatic pymodbus version detection:

1. **New compatibility function** in `const.py`:
   - `get_pymodbus_device_param()` automatically detects pymodbus version
   - Returns `"device_id"` for pymodbus >= 3.10.0
   - Returns `"slave"` for pymodbus < 3.10.0
   - Secure fallback in case of error

2. **Updated pymodbus calls**:
   - **`coordinator.py`**: 3 calls updated
   - **`config_flow.py`**: 4 calls updated
   - Using `**{device_param: value}` to pass the correct parameter

### Files Modified

- `custom_components/hitachi_yutaki/const.py`: Added detection function
- `custom_components/hitachi_yutaki/coordinator.py`: Updated 3 pymodbus calls
- `custom_components/hitachi_yutaki/config_flow.py`: Updated 4 pymodbus calls
- `CHANGELOG.md`: Documentation of the fix
- `manifest.json`: Version bump to 1.9.2
- `setup.cfg` & `Makefile`: Version bump to 1.9.2

### Related Issue

Fixes #97 