### PR TITLE
fix: use HA PowerConverter instead of naive W/kW heuristic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub branch protection: rulesets for `main` (merge-only, required CI) and `dev` (squash-only, required CI, admin bypass)
 - `CLAUDE.md`: updated branch strategy, git conventions, and translations sections
 
+### Fixed
+- Electrical power unit conversion now uses HA's `PowerConverter` instead of a naive `> 50` heuristic ([#182](https://github.com/alepee/hass-hitachi_yutaki/issues/182)) — a heat pump in standby consuming < 50 W was incorrectly interpreted as kW, causing wildly inaccurate COP values
+
 ## [2.0.0] - 2026-02-12
 
 A major rewrite of the integration with hexagonal architecture, multi-gateway support, and significantly improved accuracy for thermal and COP calculations.

--- a/custom_components/hitachi_yutaki/adapters/calculators/electrical.py
+++ b/custom_components/hitachi_yutaki/adapters/calculators/electrical.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from contextlib import suppress
 
+from homeassistant.const import UnitOfPower
+from homeassistant.util.unit_conversion import PowerConverter
+
 from ...domain.models.electrical import ElectricalPowerInput
 from ...domain.ports.calculators import ElectricalPowerCalculator
 from ...domain.services.electrical import calculate_electrical_power
@@ -51,6 +54,32 @@ class ElectricalPowerCalculatorAdapter:
             return float(state.state)
         return None
 
+    def _get_power_in_kw(self) -> float | None:
+        """Get power measurement converted to kW using HA's PowerConverter.
+
+        Reads the power entity's value and unit_of_measurement attribute,
+        then converts to kW using Home Assistant's built-in converter.
+
+        Returns:
+            Power in kW, or None if unavailable or missing unit.
+
+        """
+        entity_id = self._config_entry.data.get("power_entity")
+        if not entity_id:
+            return None
+
+        state = self._hass.states.get(entity_id)
+        if not state or state.state in (None, "unknown", "unavailable"):
+            return None
+
+        with suppress(ValueError):
+            value = float(state.state)
+            from_unit = state.attributes.get("unit_of_measurement")
+            if from_unit is None:
+                return None
+            return PowerConverter.convert(value, from_unit, UnitOfPower.KILO_WATT)
+        return None
+
     def __call__(self, current: float) -> float:
         """Calculate electrical power in kW.
 
@@ -68,7 +97,7 @@ class ElectricalPowerCalculatorAdapter:
         return calculate_electrical_power(
             ElectricalPowerInput(
                 current=current,
-                measured_power=self._get_float_from_entity("power_entity"),
+                measured_power=self._get_power_in_kw(),
                 voltage=self._get_float_from_entity("voltage_entity"),
                 is_three_phase=self._is_three_phase,
             )

--- a/custom_components/hitachi_yutaki/domain/models/electrical.py
+++ b/custom_components/hitachi_yutaki/domain/models/electrical.py
@@ -10,6 +10,6 @@ class ElectricalPowerInput:
     """Input data for electrical power calculation."""
 
     current: float  # Amperes
-    measured_power: float | None = None  # kW (if directly measured)
+    measured_power: float | None = None  # kW (normalized by adapter)
     voltage: float | None = None  # Volts
     is_three_phase: bool = False  # True for 3-phase, False for single-phase

--- a/custom_components/hitachi_yutaki/domain/services/electrical.py
+++ b/custom_components/hitachi_yutaki/domain/services/electrical.py
@@ -29,14 +29,9 @@ def calculate_electrical_power(data: ElectricalPowerInput) -> float:
         Electrical power in kW
 
     """
-    # Priority 1: Use direct power measurement if available
+    # Priority 1: Use direct power measurement if available (already in kW)
     if data.measured_power is not None:
-        # Simple heuristic to convert W to kW if necessary
-        return (
-            data.measured_power / 1000
-            if data.measured_power > 50
-            else data.measured_power
-        )
+        return data.measured_power
 
     # Priority 2: Calculate from voltage and current
     voltage = data.voltage

--- a/tests/domain/services/test_electrical.py
+++ b/tests/domain/services/test_electrical.py
@@ -1,0 +1,66 @@
+"""Tests for electrical power calculation service."""
+
+from custom_components.hitachi_yutaki.domain.models.electrical import (
+    ElectricalPowerInput,
+)
+from custom_components.hitachi_yutaki.domain.services.electrical import (
+    POWER_FACTOR,
+    THREE_PHASE_FACTOR,
+    VOLTAGE_SINGLE_PHASE,
+    VOLTAGE_THREE_PHASE,
+    calculate_electrical_power,
+)
+
+
+def test_measured_power_used_directly():
+    """Measured power (already in kW from adapter) is returned as-is."""
+    data = ElectricalPowerInput(current=10.0, measured_power=2.5)
+    assert calculate_electrical_power(data) == 2.5
+
+
+def test_measured_power_small_value_not_divided():
+    """Small measured_power values are no longer divided by 1000.
+
+    Regression test for issue #182: a heat pump in standby consuming 0.03 kW
+    must NOT be treated as 30 kW.
+    """
+    data = ElectricalPowerInput(current=10.0, measured_power=0.03)
+    assert calculate_electrical_power(data) == 0.03
+
+
+def test_fallback_to_voltage_current_single_phase():
+    """Without measured_power, single-phase P = U * I * cos(phi) / 1000."""
+    data = ElectricalPowerInput(
+        current=10.0, voltage=230.0, is_three_phase=False
+    )
+    expected = (230.0 * 10.0 * POWER_FACTOR) / 1000
+    assert calculate_electrical_power(data) == expected
+
+
+def test_fallback_to_voltage_current_three_phase():
+    """Without measured_power, three-phase P = U * I * cos(phi) * sqrt(3) / 1000."""
+    data = ElectricalPowerInput(
+        current=10.0, voltage=400.0, is_three_phase=True
+    )
+    expected = (400.0 * 10.0 * POWER_FACTOR * THREE_PHASE_FACTOR) / 1000
+    assert calculate_electrical_power(data) == expected
+
+
+def test_fallback_to_default_voltage_single_phase():
+    """Without voltage, default single-phase voltage (230V) is used."""
+    data = ElectricalPowerInput(current=10.0, is_three_phase=False)
+    expected = (VOLTAGE_SINGLE_PHASE * 10.0 * POWER_FACTOR) / 1000
+    assert calculate_electrical_power(data) == expected
+
+
+def test_fallback_to_default_voltage_three_phase():
+    """Without voltage, default three-phase voltage (400V) is used."""
+    data = ElectricalPowerInput(current=10.0, is_three_phase=True)
+    expected = (VOLTAGE_THREE_PHASE * 10.0 * POWER_FACTOR * THREE_PHASE_FACTOR) / 1000
+    assert calculate_electrical_power(data) == expected
+
+
+def test_measured_power_zero():
+    """Zero measured power is returned as-is (not treated as None)."""
+    data = ElectricalPowerInput(current=10.0, measured_power=0.0)
+    assert calculate_electrical_power(data) == 0.0


### PR DESCRIPTION
## Summary

Closes #182

- Replace the naive `> 50` W/kW heuristic in `domain/services/electrical.py` with proper unit conversion using HA's `PowerConverter` in the adapter layer
- The adapter now reads the entity's `unit_of_measurement` attribute and converts to kW, so the domain service always receives normalized values
- A heat pump in standby consuming < 50 W was previously misinterpreted as 50 kW, causing wildly inaccurate COP values

## Changes

| File | What |
|------|------|
| `adapters/calculators/electrical.py` | New `_get_power_in_kw()` using `PowerConverter` + `unit_of_measurement` |
| `domain/services/electrical.py` | Remove `> 50` heuristic — trust adapter-normalized kW |
| `domain/models/electrical.py` | Clarify `measured_power` comment: `kW (normalized by adapter)` |
| `tests/domain/services/test_electrical.py` | 7 new tests for the domain service |
| `CHANGELOG.md` | Add entry under `[Unreleased] > Fixed` |

## Test plan

- [x] `uv run pytest tests/domain/services/test_electrical.py -v` — 7/7 pass
- [x] `uv run pytest tests/domain/ -v` — 49/49 pass
- [x] `uv run ruff check custom_components --fix` — clean
- [ ] Manual test with a power entity reporting W (e.g. Shelly) to confirm correct kW conversion