### PR TITLE
fix: remove phantom secondary compressor pressure registers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Remove phantom secondary compressor pressure registers at non-existent addresses 1150/1151 (#225)
 - Scan interval not editable in reconfiguration flow (options flow missing the field)
 
 ### Changed

--- a/custom_components/hitachi_yutaki/api/modbus/registers/atw_mbs_02.py
+++ b/custom_components/hitachi_yutaki/api/modbus/registers/atw_mbs_02.py
@@ -270,12 +270,6 @@ REGISTER_SECONDARY_COMPRESSOR = {
         1230, deserializer=convert_from_tenths
     ),
     "secondary_compressor_retry_code": RegisterDefinition(1231),
-    "secondary_compressor_hp_pressure": RegisterDefinition(
-        1150, deserializer=convert_pressure
-    ),
-    "secondary_compressor_lp_pressure": RegisterDefinition(
-        1151, deserializer=convert_pressure
-    ),
 }
 
 REGISTER_CIRCUIT_1 = {

--- a/custom_components/hitachi_yutaki/profiles/yutaki_s80.py
+++ b/custom_components/hitachi_yutaki/profiles/yutaki_s80.py
@@ -93,6 +93,4 @@ class YutakiS80Profile(HitachiHeatPumpProfile):
             "secondary_compressor_valve_opening",
             "secondary_compressor_current",
             "secondary_compressor_retry_code",
-            "secondary_compressor_hp_pressure",
-            "secondary_compressor_lp_pressure",
         ]


### PR DESCRIPTION
## Summary
- Remove register definitions for non-existent addresses 1150/1151 (`secondary_compressor_hp_pressure` / `secondary_compressor_lp_pressure`) from ATW-MBS-02 register map
- Remove corresponding keys from S80 profile's `extra_register_keys`
- These phantom registers caused 2 Modbus read errors per polling cycle for S80 users
- The correct equivalents (`discharge_pressure` at 1226, `suction_pressure` at 1227) were already defined and used

Closes #225

## Test plan
- [x] `make lint` — all checks passed
- [x] `make test` — 157 tests passed
- [x] Grep confirms zero remaining references to `hp_pressure`/`lp_pressure` in source