### PR TITLE
fix: remove incorrect tenths conversion on pool target temperature

### DIFF
--- a/custom_components/hitachi_yutaki/api/modbus/registers/atw_mbs_02.py
+++ b/custom_components/hitachi_yutaki/api/modbus/registers/atw_mbs_02.py
@@ -324,9 +324,7 @@ REGISTER_DHW = {
 
 REGISTER_POOL = {
     "pool_power": RegisterDefinition(1028),
-    "pool_target_temp": RegisterDefinition(
-        1029, deserializer=convert_from_tenths, serializer=lambda v: int(v * 10)
-    ),
+    "pool_target_temp": RegisterDefinition(1029),
     "pool_current_temp": RegisterDefinition(1083, deserializer=convert_signed_16bit),
 }
 

--- a/custom_components/hitachi_yutaki/api/modbus/registers/hc_a_mb.py
+++ b/custom_components/hitachi_yutaki/api/modbus/registers/hc_a_mb.py
@@ -468,7 +468,7 @@ class HcAMbRegisterMap(HitachiRegisterMap):
         }
 
         # --- Pool (CONTROL + STATUS) ---
-        # Note: HC-A(16/64)MB pool_target_temp is integer °C (NOT tenths like ATW-MBS-02)
+        # Note: pool_target_temp is integer °C (0~80), no tenths conversion
         self._register_pool: dict[str, RegisterDefinition] = {
             "pool_power": RegisterDefinition(
                 self._addr(132), write_address=self._addr(79)


### PR DESCRIPTION
## Summary

Fixes #233

- Remove `convert_from_tenths` deserializer and `×10` serializer from ATW-MBS-02 `pool_target_temp` register (1029) — the gateway stores integer °C (0–80), not tenths
- Update outdated comment in HC-A(16/64)MB register map

The pool setting temperature register has the same format as DHW (`0~80 °C`), which was already handled correctly without conversion. The tenths conversion caused a value like 28°C to display as 2.8°C in Home Assistant.

## Test plan

- [x] `make check` passes
- [x] `make test` passes (168 tests)
- [ ] User with pool confirms correct temperature display after update