### PR TITLE
fix(telemetry): parallelize TigerData and R2 writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Telemetry backend: parallelize TigerData and R2 writes via `Promise.allSettled` so that an R2 archive is performed even when the TigerData insert fails. Previously the R2 archive was only attempted after a successful database write, which meant payloads received during a TigerData outage were lost (#284)
+- Telemetry backend: parallelize TigerData and R2 writes via `Promise.allSettled` so that an R2 archive is performed even when the TigerData insert fails. Previously the R2 archive was only attempted after a successful database write, which meant payloads received during a TigerData outage were lost. The endpoint now returns `202` when at least one sink succeeds, and `502 Bad Gateway` only when both upstream sinks fail (#284)
 
 ## [2.1.0] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Telemetry backend: parallelize TigerData and R2 writes via `Promise.allSettled` so that an R2 archive is performed even when the TigerData insert fails. Previously the R2 archive was only attempted after a successful database write, which meant payloads received during a TigerData outage were lost (#284)
+
 ## [2.1.0] - 2026-04-24
 
 This release adds support for pre-2016 ATW-MBS-02 gateways (Gen 1 Yutaki S/S Combi), an opt-in anonymous telemetry system to grow realistic test fixtures across all heat pump models, and an electricity cost estimation feature. Internally, derived metrics (COP, thermal/electrical power, compressor timing) are now centralized in a single adapter, fixing COP accuracy for S80 cascade installations.

--- a/backend/worker/src/archive.ts
+++ b/backend/worker/src/archive.ts
@@ -33,7 +33,9 @@ function shortHash(instanceHash: string): string {
 
 /**
  * Archive a validated payload to R2.
- * Fire-and-forget: caller should catch errors and log, not fail the request.
+ * Throws on R2 failure; the caller decides how to handle it
+ * (currently: combined with the TigerData result via Promise.allSettled,
+ * the request only fails when both sinks reject).
  */
 export async function archiveToR2(
   bucket: R2Bucket,

--- a/backend/worker/src/index.ts
+++ b/backend/worker/src/index.ts
@@ -5,8 +5,8 @@
  *   - Accepts gzipped or plain JSON
  *   - Validates and sanitizes payload (field whitelist)
  *   - Rate limits per instance_hash (1 req/min via Cache API)
- *   - Dual write: TigerData (hot, 30-day) + R2 (cold, permanent)
- *   - Returns 202 Accepted on success
+ *   - Dual write in parallel: TigerData (hot, 30-day) + R2 (cold, permanent)
+ *   - Returns 202 Accepted if at least one sink succeeds, 500 only when both fail
  */
 
 import { archiveToR2 } from "./archive";
@@ -53,14 +53,23 @@ export default {
         }
       }
 
-      // Dual write: hot (TigerData) + cold (R2)
-      await writeToDatabase(env, payload);
+      // Dual write in parallel — neither sink blocks the other.
+      // Success requires at least one sink to accept the payload.
+      const [dbResult, r2Result] = await Promise.allSettled([
+        writeToDatabase(env, payload),
+        archiveToR2(env.ARCHIVE, payload),
+      ]);
 
-      // R2 archive is fire-and-forget
-      try {
-        await archiveToR2(env.ARCHIVE, payload);
-      } catch (err) {
-        console.warn("R2 archive failed (non-fatal):", err);
+      if (dbResult.status === "rejected") {
+        console.warn("TigerData write failed:", dbResult.reason);
+      }
+      if (r2Result.status === "rejected") {
+        console.warn("R2 archive failed:", r2Result.reason);
+      }
+
+      if (dbResult.status === "rejected" && r2Result.status === "rejected") {
+        console.error("Ingestion error: both sinks failed");
+        return new Response("Internal Server Error", { status: 500 });
       }
 
       return new Response(null, { status: 202 });

--- a/backend/worker/src/index.ts
+++ b/backend/worker/src/index.ts
@@ -6,7 +6,7 @@
  *   - Validates and sanitizes payload (field whitelist)
  *   - Rate limits per instance_hash (1 req/min via Cache API)
  *   - Dual write in parallel: TigerData (hot, 30-day) + R2 (cold, permanent)
- *   - Returns 202 Accepted if at least one sink succeeds, 500 only when both fail
+ *   - Returns 202 Accepted if at least one sink succeeds, 502 Bad Gateway when both fail
  */
 
 import { archiveToR2 } from "./archive";
@@ -69,7 +69,7 @@ export default {
 
       if (dbResult.status === "rejected" && r2Result.status === "rejected") {
         console.error("Ingestion error: both sinks failed");
-        return new Response("Internal Server Error", { status: 500 });
+        return new Response("Both telemetry sinks unavailable", { status: 502 });
       }
 
       return new Response(null, { status: 202 });


### PR DESCRIPTION
## Summary
- The Worker now writes TigerData and R2 in parallel via `Promise.allSettled`. The endpoint returns `202` as long as at least one sink accepts the payload, and `502 Bad Gateway` only when both upstream sinks fail.
- Previously the R2 archive call was only reached **after** a successful TigerData insert. When TigerData becomes unavailable (e.g. quota overrun → read-only mode, see #284), every payload was lost despite R2 still being healthy.
- `502` is preferred over `500` because the Worker is conceptually a proxy between two upstream sinks; when both reject the payload, that is exactly what `Bad Gateway` describes (vs. `500` which implies an internal Worker bug).
- Side benefit: while TigerData is degraded, clients receive `202` from R2 alone, so the integration stops emitting the recurring `Telemetry send failed after 4 attempts` warning in Home Assistant logs.

## Test plan
- [x] `npx tsc --noEmit` passes in `backend/worker/`
- [ ] Deploy and verify with `wrangler tail`:
  - happy path → `202`, both sinks succeed silently
  - simulated TigerData failure → `202` + `TigerData write failed` warn log
  - simulated R2 failure → `202` + `R2 archive failed` warn log
  - both sinks fail → `502` + `Ingestion error: both sinks failed` error log
- [ ] After deploy, confirm the Home Assistant warning disappears for opted-in users while TigerData is still in read-only.

Refs #284