### PR TITLE
chore(worker): enable observability logs

### DIFF
--- a/backend/worker/wrangler.toml
+++ b/backend/worker/wrangler.toml
@@ -10,3 +10,8 @@ bucket_name = "hitachi-telemetry-archive"
 [[hyperdrive]]
 binding = "DB"
 id = "6022ba5b4aa84149bced9823002142d7"
+
+[observability]
+[observability.logs]
+enabled = true
+invocation_logs = true


### PR DESCRIPTION
## Summary
- Enable Cloudflare Workers observability with invocation logs for the telemetry worker (`backend/worker/wrangler.toml`).
- Eases debugging and monitoring of ingestion errors.

## Test plan
- [x] `npx wrangler deploy` succeeds after merge
- [x] Logs visible in Cloudflare dashboard under Workers > hitachi-telemetry > Logs