### PR TITLE
fix(modbus): read ATW-MBS-02 R/W registers from STATUS, not CONTROL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Telemetry backend: Cloudflare R2 is now the single source of truth. The Worker no longer dual-writes to TimescaleDB / TigerData; the `pg` driver, `db.ts` module, and Hyperdrive binding have been removed. R2 partitioning (`metrics/year=YYYY/month=MM/day=DD/`) is unchanged. Notebooks should consume the JSON archive directly via DuckDB + httpfs.
 
 ### Fixed
+- ATW-MBS-02: read R/W registers from STATUS addresses instead of CONTROL. The CONTROL range only reflects what was last commanded; STATUS reflects what the unit is actually using. This fixes silent divergences when the unit internally overrides a setpoint (anti-legionella cycle, OTC adjustment, central-control conflict). Affects both Line-up 2016 (29 keys) and Before Line-up 2016 (19 keys) maps. Writes still target CONTROL via the existing `write_address` mechanism, mirroring the HC-A(16/64)MB pattern. Likely root cause of the DHW reference temperature jumping reported in #293 (#295)
 - Telemetry backend: parallelize TigerData and R2 writes via `Promise.allSettled` so that an R2 archive is performed even when the TigerData insert fails. Previously the R2 archive was only attempted after a successful database write, which meant payloads received during a TigerData outage were lost. The endpoint now returns `202` when at least one sink succeeds, and `502 Bad Gateway` only when both upstream sinks fail (#284)
 
 ## [2.1.0] - 2026-04-24

--- a/custom_components/hitachi_yutaki/api/modbus/registers/atw_mbs_02.py
+++ b/custom_components/hitachi_yutaki/api/modbus/registers/atw_mbs_02.py
@@ -239,8 +239,8 @@ REGISTER_GATEWAY = {
 }
 
 REGISTER_CONTROL_UNIT = {
-    "unit_power": RegisterDefinition(1000),
-    "unit_mode": RegisterDefinition(1001),
+    "unit_power": RegisterDefinition(1050, write_address=1000),
+    "unit_mode": RegisterDefinition(1051, write_address=1001),
     "operation_state": RegisterDefinition(
         1090, deserializer=deserialize_operation_state
     ),
@@ -305,48 +305,56 @@ REGISTER_SECONDARY_COMPRESSOR = {
 }
 
 REGISTER_CIRCUIT_1 = {
-    "circuit1_power": RegisterDefinition(1002),
+    "circuit1_power": RegisterDefinition(1052, write_address=1002),
     "circuit1_otc_calculation_method_heating": RegisterDefinition(
-        1003, deserializer=deserialize_otc_method_heating
+        1053, deserializer=deserialize_otc_method_heating, write_address=1003
     ),
     "circuit1_otc_calculation_method_cooling": RegisterDefinition(
-        1004, deserializer=deserialize_otc_method_cooling
+        1054, deserializer=deserialize_otc_method_cooling, write_address=1004
     ),
-    "circuit1_max_flow_temp_heating_otc": RegisterDefinition(1005),
-    "circuit1_max_flow_temp_cooling_otc": RegisterDefinition(1006),
-    "circuit1_eco_mode": RegisterDefinition(1007),
-    "circuit1_heat_eco_offset": RegisterDefinition(1008),
-    "circuit1_cool_eco_offset": RegisterDefinition(1009),
+    "circuit1_max_flow_temp_heating_otc": RegisterDefinition(1055, write_address=1005),
+    "circuit1_max_flow_temp_cooling_otc": RegisterDefinition(1056, write_address=1006),
+    "circuit1_eco_mode": RegisterDefinition(1057, write_address=1007),
+    "circuit1_heat_eco_offset": RegisterDefinition(1058, write_address=1008),
+    "circuit1_cool_eco_offset": RegisterDefinition(1059, write_address=1009),
     "circuit1_thermostat": RegisterDefinition(1010),
-    "circuit1_target_temp": RegisterDefinition(1011, deserializer=convert_from_tenths),
-    "circuit1_current_temp": RegisterDefinition(1012, deserializer=convert_from_tenths),
+    "circuit1_target_temp": RegisterDefinition(
+        1060, deserializer=convert_from_tenths, write_address=1011
+    ),
+    "circuit1_current_temp": RegisterDefinition(
+        1061, deserializer=convert_from_tenths, write_address=1012
+    ),
 }
 
 REGISTER_CIRCUIT_2 = {
-    "circuit2_power": RegisterDefinition(1013),
+    "circuit2_power": RegisterDefinition(1064, write_address=1013),
     "circuit2_otc_calculation_method_heating": RegisterDefinition(
-        1014, deserializer=deserialize_otc_method_heating
+        1065, deserializer=deserialize_otc_method_heating, write_address=1014
     ),
     "circuit2_otc_calculation_method_cooling": RegisterDefinition(
-        1015, deserializer=deserialize_otc_method_cooling
+        1066, deserializer=deserialize_otc_method_cooling, write_address=1015
     ),
-    "circuit2_max_flow_temp_heating_otc": RegisterDefinition(1016),
-    "circuit2_max_flow_temp_cooling_otc": RegisterDefinition(1017),
-    "circuit2_eco_mode": RegisterDefinition(1018),
-    "circuit2_heat_eco_offset": RegisterDefinition(1019),
-    "circuit2_cool_eco_offset": RegisterDefinition(1020),
+    "circuit2_max_flow_temp_heating_otc": RegisterDefinition(1067, write_address=1016),
+    "circuit2_max_flow_temp_cooling_otc": RegisterDefinition(1068, write_address=1017),
+    "circuit2_eco_mode": RegisterDefinition(1069, write_address=1018),
+    "circuit2_heat_eco_offset": RegisterDefinition(1070, write_address=1019),
+    "circuit2_cool_eco_offset": RegisterDefinition(1071, write_address=1020),
     "circuit2_thermostat": RegisterDefinition(1021),
-    "circuit2_target_temp": RegisterDefinition(1022, deserializer=convert_from_tenths),
-    "circuit2_current_temp": RegisterDefinition(1023, deserializer=convert_from_tenths),
+    "circuit2_target_temp": RegisterDefinition(
+        1072, deserializer=convert_from_tenths, write_address=1022
+    ),
+    "circuit2_current_temp": RegisterDefinition(
+        1073, deserializer=convert_from_tenths, write_address=1023
+    ),
 }
 
 REGISTER_DHW = {
-    "dhw_power": RegisterDefinition(1024),
-    "dhw_target_temp": RegisterDefinition(1025),
-    "dhw_boost": RegisterDefinition(1026),
-    "dhw_high_demand": RegisterDefinition(1027),
-    "dhw_antilegionella": RegisterDefinition(1030),
-    "dhw_antilegionella_temp": RegisterDefinition(1031),
+    "dhw_power": RegisterDefinition(1076, write_address=1024),
+    "dhw_target_temp": RegisterDefinition(1077, write_address=1025),
+    "dhw_boost": RegisterDefinition(1078, write_address=1026),
+    "dhw_high_demand": RegisterDefinition(1079, write_address=1027),
+    "dhw_antilegionella": RegisterDefinition(1084, write_address=1030),
+    "dhw_antilegionella_temp": RegisterDefinition(1085, write_address=1031),
     "dhw_demand_mode": RegisterDefinition(1079),
     "dhw_current_temp": RegisterDefinition(
         1080, deserializer=convert_signed_16bit, sentinel_values=frozenset({-67})
@@ -356,8 +364,8 @@ REGISTER_DHW = {
 }
 
 REGISTER_POOL = {
-    "pool_power": RegisterDefinition(1028),
-    "pool_target_temp": RegisterDefinition(1029),
+    "pool_power": RegisterDefinition(1081, write_address=1028),
+    "pool_target_temp": RegisterDefinition(1082, write_address=1029),
     "pool_current_temp": RegisterDefinition(
         1083, deserializer=convert_signed_16bit, sentinel_values=frozenset({-127})
     ),

--- a/custom_components/hitachi_yutaki/api/modbus/registers/atw_mbs_02_pre2016.py
+++ b/custom_components/hitachi_yutaki/api/modbus/registers/atw_mbs_02_pre2016.py
@@ -99,7 +99,7 @@ REGISTER_GATEWAY = {
 
 REGISTER_CONTROL_UNIT = {
     "unit_power": RegisterDefinition(1000),
-    "unit_mode": RegisterDefinition(1001),
+    "unit_mode": RegisterDefinition(1050, write_address=1001),
     "operation_state": RegisterDefinition(
         1077, deserializer=deserialize_operation_state
     ),
@@ -165,40 +165,48 @@ REGISTER_SECONDARY_COMPRESSOR = {
 }
 
 REGISTER_CIRCUIT_1 = {
-    "circuit1_power": RegisterDefinition(1002),
+    "circuit1_power": RegisterDefinition(1051, write_address=1002),
     "circuit1_otc_calculation_method_heating": RegisterDefinition(
-        1003, deserializer=deserialize_otc_method_heating
+        1052, deserializer=deserialize_otc_method_heating, write_address=1003
     ),
     "circuit1_otc_calculation_method_cooling": RegisterDefinition(
-        1004, deserializer=deserialize_otc_method_cooling
+        1053, deserializer=deserialize_otc_method_cooling, write_address=1004
     ),
-    "circuit1_target_temp": RegisterDefinition(1005, deserializer=convert_from_tenths),
-    "circuit1_current_temp": RegisterDefinition(1006, deserializer=convert_from_tenths),
-    "circuit1_max_flow_temp_heating_otc": RegisterDefinition(1007),
-    "circuit1_max_flow_temp_cooling_otc": RegisterDefinition(1008),
+    "circuit1_target_temp": RegisterDefinition(
+        1054, deserializer=convert_from_tenths, write_address=1005
+    ),
+    "circuit1_current_temp": RegisterDefinition(
+        1055, deserializer=convert_from_tenths, write_address=1006
+    ),
+    "circuit1_max_flow_temp_heating_otc": RegisterDefinition(1056, write_address=1007),
+    "circuit1_max_flow_temp_cooling_otc": RegisterDefinition(1057, write_address=1008),
     "circuit1_thermostat": RegisterDefinition(1029),
 }
 
 REGISTER_CIRCUIT_2 = {
-    "circuit2_power": RegisterDefinition(1009),
+    "circuit2_power": RegisterDefinition(1058, write_address=1009),
     "circuit2_otc_calculation_method_heating": RegisterDefinition(
-        1010, deserializer=deserialize_otc_method_heating
+        1059, deserializer=deserialize_otc_method_heating, write_address=1010
     ),
     "circuit2_otc_calculation_method_cooling": RegisterDefinition(
-        1011, deserializer=deserialize_otc_method_cooling
+        1060, deserializer=deserialize_otc_method_cooling, write_address=1011
     ),
-    "circuit2_target_temp": RegisterDefinition(1012, deserializer=convert_from_tenths),
-    "circuit2_current_temp": RegisterDefinition(1013, deserializer=convert_from_tenths),
-    "circuit2_max_flow_temp_heating_otc": RegisterDefinition(1014),
-    "circuit2_max_flow_temp_cooling_otc": RegisterDefinition(1015),
+    "circuit2_target_temp": RegisterDefinition(
+        1061, deserializer=convert_from_tenths, write_address=1012
+    ),
+    "circuit2_current_temp": RegisterDefinition(
+        1062, deserializer=convert_from_tenths, write_address=1013
+    ),
+    "circuit2_max_flow_temp_heating_otc": RegisterDefinition(1063, write_address=1014),
+    "circuit2_max_flow_temp_cooling_otc": RegisterDefinition(1064, write_address=1015),
     "circuit2_thermostat": RegisterDefinition(1029),
 }
 
 REGISTER_DHW = {
-    "dhw_power": RegisterDefinition(1016),
-    "dhw_target_temp": RegisterDefinition(1017),
-    "dhw_antilegionella": RegisterDefinition(1020),
-    "dhw_antilegionella_temp": RegisterDefinition(1021),
+    "dhw_power": RegisterDefinition(1065, write_address=1016),
+    "dhw_target_temp": RegisterDefinition(1066, write_address=1017),
+    "dhw_antilegionella": RegisterDefinition(1069, write_address=1020),
+    "dhw_antilegionella_temp": RegisterDefinition(1070, write_address=1021),
     "dhw_current_temp": RegisterDefinition(
         1075, deserializer=convert_signed_16bit, sentinel_values=frozenset({-67})
     ),
@@ -207,8 +215,8 @@ REGISTER_DHW = {
 }
 
 REGISTER_POOL = {
-    "pool_power": RegisterDefinition(1018),
-    "pool_target_temp": RegisterDefinition(1019),
+    "pool_power": RegisterDefinition(1067, write_address=1018),
+    "pool_target_temp": RegisterDefinition(1068, write_address=1019),
     "pool_current_temp": RegisterDefinition(
         1076, deserializer=convert_signed_16bit, sentinel_values=frozenset({-127})
     ),

--- a/tests/api/modbus/registers/test_atw_mbs_02_pre2016.py
+++ b/tests/api/modbus/registers/test_atw_mbs_02_pre2016.py
@@ -61,7 +61,8 @@ class TestPre2016RegisterMap:
             "outdoor_temp": 1078,
             "water_inlet_temp": 1079,
             "unit_model": 1217,
-            "dhw_power": 1016,
+            # dhw_power reads from STATUS (1065) since #295; writes go to CONTROL 1016
+            "dhw_power": 1065,
             "dhw_current_temp": 1075,
             "system_config": 1074,
         }

--- a/tests/api/modbus/registers/test_compatibility.py
+++ b/tests/api/modbus/registers/test_compatibility.py
@@ -134,6 +134,81 @@ class TestKeyNamingCompatibility:
             assert key in hca.all_registers, f"Writable key {key} not in all_registers"
 
 
+class TestStatusReadInvariant:
+    """Every writable key must read from STATUS, with rare documented exceptions.
+
+    See issue #295: reading from CONTROL returns the last commanded value rather
+    than what the unit is actually using, which masks internal overrides
+    (anti-legionella, OTC adjustment, central-control conflicts).
+    """
+
+    # Keys that have no STATUS counterpart in the gateway documentation
+    # and must therefore read from CONTROL. Keep this set tight — adding an
+    # entry without a documented justification re-introduces the bug class.
+    ATW_MBS_02_EXCEPTIONS = {
+        # No STATUS "Room thermostat available" bit in the 2016 R section
+        "circuit1_thermostat",
+        "circuit2_thermostat",
+    }
+    ATW_MBS_02_PRE2016_EXCEPTIONS = {
+        # No Status Unit Run/Stop in pre-2016 (only Status Unit Mode)
+        "unit_power",
+        # No STATUS counterpart for "Room thermostat available" pre-2016
+        "circuit1_thermostat",
+        "circuit2_thermostat",
+    }
+
+    HC_A_MB_EXCEPTIONS = {
+        # CONTROL-only: no STATUS counterpart for "Room thermostat available"
+        "circuit1_thermostat",
+        "circuit2_thermostat",
+    }
+
+    def _assert_split(self, register_map, exceptions, gateway_label):
+        for key in register_map.writable_keys:
+            reg = register_map.all_registers[key]
+            if key in exceptions:
+                # CONTROL-only key: either write_address is unset, or it equals
+                # address (defensive duplication). Both mean "reads the same
+                # CONTROL register that writes target".
+                if reg.write_address is not None:
+                    assert reg.write_address == reg.address, (
+                        f"{gateway_label}: {key} is a CONTROL-only exception "
+                        f"but read ({reg.address}) and write ({reg.write_address}) "
+                        f"addresses differ."
+                    )
+                continue
+            assert reg.write_address is not None, (
+                f"{gateway_label}: writable key {key} reads from CONTROL "
+                f"({reg.address}); should read from STATUS and set write_address. "
+                f"See issue #295."
+            )
+            assert reg.address != reg.write_address, (
+                f"{gateway_label}: {key} read and write addresses are equal "
+                f"({reg.address}) — STATUS/CONTROL split missing."
+            )
+
+    def test_atw_mbs_02_writes_separate_from_reads(self):
+        """ATW-MBS-02 (2016): every R/W key reads STATUS, writes CONTROL."""
+        self._assert_split(
+            AtwMbs02RegisterMap(),
+            self.ATW_MBS_02_EXCEPTIONS,
+            "ATW-MBS-02",
+        )
+
+    def test_atw_mbs_02_pre2016_writes_separate_from_reads(self):
+        """ATW-MBS-02 pre-2016: every R/W key reads STATUS, writes CONTROL."""
+        self._assert_split(
+            AtwMbs02Pre2016RegisterMap(),
+            self.ATW_MBS_02_PRE2016_EXCEPTIONS,
+            "ATW-MBS-02 Pre-2016",
+        )
+
+    def test_hc_a_mb_writes_separate_from_reads(self):
+        """HC-A(16/64)MB: every R/W key reads STATUS offset, writes CONTROL offset."""
+        self._assert_split(HcAMbRegisterMap(), self.HC_A_MB_EXCEPTIONS, "HC-A(16/64)MB")
+
+
 class TestBitMasks:
     """Test bit mask values across gateways."""
 


### PR DESCRIPTION
## Summary

Fixes #295. Likely root cause of the DHW reference temperature divergence reported in #293.

The ATW-MBS-02 register maps were reading R/W keys from their **CONTROL** address — i.e. the value last commanded — rather than the **STATUS** address that reflects what the unit is actually using. This silently masked any internal override (anti-legionella cycle, OTC adjustment, central-control conflict), so Home Assistant could report a setpoint that no longer matched the running configuration.

A first partial fix in v1.10.0 added separate `_status` keys for anti-legionella entities only. This change generalizes the fix across both register maps using the existing HC-A(16/64)MB pattern: each `RegisterDefinition` now reads from `STATUS` with `write_address` pointing at `CONTROL`.

- **`atw_mbs_02.py` (Line-up 2016)**: 31 keys rerouted (`unit_power`, `unit_mode`, 11×circuit1, 11×circuit2, 4×DHW + 2×anti-legionella, 2×pool). `circuit1/2_thermostat` left as CONTROL-only — no STATUS counterpart documented.
- **`atw_mbs_02_pre2016.py` (Before Line-up 2016)**: 21 keys rerouted. `unit_power` and `circuit1/2_thermostat` left CONTROL-only — no STATUS counterpart documented for these.
- **Invariant test**: new `TestStatusReadInvariant` in `test_compatibility.py` checks all three gateways and fails if any writable key reads from CONTROL outside a documented exception list. Prevents this bug class from coming back.

## Verification

- `make check` and `make test` clean (323 passed).
- Live verification on my Yutaki S80 gateway: all 32 writable keys in the 2016 map read sensible values from their new STATUS addresses, deserializers still apply, thermostat exceptions correctly fall back to CONTROL.
- Pre-2016 path validated by tests only (no Gen-1 hardware available).

## Test plan

- [x] Existing register tests pass.
- [x] New invariant test exercises all three gateways.
- [x] Live read on Yutaki S80 with patched map returns expected values for circuit1, DHW, anti-legionella, pool registers.
- [ ] Confirm with a #293 reporter that DHW reference temperature stays consistent after upgrade.