### PR TITLE
fix(config-flow): surface gateway_not_ready instead of crashing (#300)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Config flow: surface a clear `gateway_not_ready` error (with H-LINK troubleshooting hints) instead of crashing with `TypeError` when the gateway reports an unhealthy `system_state` (initializing or desynchronized) during integration setup. Affects both ATW-MBS-02 and HC-A(16/64)MB providers. Regression introduced in 2.1.0-beta.2 (#260): the new short-circuit in `read_values` was not propagated to the config providers (#300).
+
+### Changed
+- `ReadResult` enum and `read_values` now document the contract explicitly: callers MUST check the return value before consuming `read_value()` output, since `GATEWAY_NOT_READY` short-circuits before populating internal data.
+- `decode_config` defensively coerces a missing/None `system_config` to `0` instead of raising, so an upstream contract violation degrades to "no modules detected" rather than crashing.
+
 ## [2.1.1] - 2026-05-25
 
 ### Added

--- a/custom_components/hitachi_yutaki/api/base.py
+++ b/custom_components/hitachi_yutaki/api/base.py
@@ -8,7 +8,21 @@ from custom_components.hitachi_yutaki.const import CIRCUIT_IDS, CIRCUIT_MODES
 
 
 class ReadResult(Enum):
-    """Result of a read_values operation."""
+    """Result of a read_values operation.
+
+    Callers MUST check this return value before reading individual register
+    values via read_value(). Contract:
+
+    - SUCCESS: requested keys were read and _data is populated. read_value()
+      will return the actual register values (or None if a specific register
+      failed/was filtered as a sentinel).
+    - GATEWAY_NOT_READY: the gateway reported an unhealthy system_state
+      (initializing or desynchronized from the heat pump). read_values()
+      short-circuited BEFORE reading any of the requested keys, so _data is
+      NOT populated and read_value() will return None for all of them.
+      Callers must surface a user-facing error and not attempt to use the
+      values.
+    """
 
     SUCCESS = "success"
     GATEWAY_NOT_READY = "gateway_not_ready"
@@ -69,7 +83,13 @@ class HitachiApiClient(ABC):
 
     @abstractmethod
     async def read_values(self, keys_to_read: list[str]) -> ReadResult:
-        """Fetch data from the heat pump for the given keys."""
+        """Fetch data from the heat pump for the given keys.
+
+        Callers MUST inspect the returned ReadResult. See ReadResult for the
+        full contract. On GATEWAY_NOT_READY, none of the requested keys were
+        read; callers must not consume read_value() output and should surface
+        an appropriate error to the user.
+        """
 
     @property
     @abstractmethod

--- a/custom_components/hitachi_yutaki/api/config_providers/atw_mbs_02.py
+++ b/custom_components/hitachi_yutaki/api/config_providers/atw_mbs_02.py
@@ -30,6 +30,7 @@ from ...const import (
 )
 from ...profiles import PROFILES
 from .. import GATEWAY_INFO, create_register_map
+from ..base import ReadResult
 from ..modbus.registers import GATEWAY_VARIANTS
 from . import StepOutcome, StepSchema
 
@@ -120,11 +121,13 @@ class AtwMbs02ConfigProvider:
             ),
         }
 
-        # Test basic connectivity
-        if not await self._test_connection(hass, config):
-            return StepOutcome(errors={"base": "cannot_connect"})
+        # Test basic connectivity (also detects unhealthy gateway state).
+        ok, error = await self._test_connection(hass, config)
+        if not ok:
+            return StepOutcome(errors={"base": error or "cannot_connect"})
 
-        # Auto-detect variant for the next step
+        # Auto-detect variant for the next step. Failures here are
+        # non-fatal: the user can still pick the variant manually.
         detected_variant = await self._detect_variant(hass, config)
         config["_detected_variant"] = detected_variant or ""
 
@@ -194,11 +197,17 @@ class AtwMbs02ConfigProvider:
     async def _test_connection(
         hass: HomeAssistant,
         config: dict[str, Any],
-    ) -> bool:
+    ) -> tuple[bool, str | None]:
         """Test basic Modbus connectivity.
 
         Uses the default (gen2) register map for the connectivity test —
         only connect + read gateway_keys to verify the gateway is reachable.
+
+        Returns (ok, error_key):
+            - (True, None) on success.
+            - (False, "cannot_connect") on network/Modbus error.
+            - (False, "gateway_not_ready") if the gateway is reachable but
+              reports an unhealthy system_state (initializing or desync).
         """
         api_client_class = GATEWAY_INFO[_GATEWAY_TYPE].client_class
         register_map = create_register_map(
@@ -214,11 +223,13 @@ class AtwMbs02ConfigProvider:
         )
         try:
             if not await api_client.connect():
-                return False
-            await api_client.read_values(api_client.register_map.gateway_keys)
-            return True
+                return False, "cannot_connect"
+            result = await api_client.read_values(api_client.register_map.gateway_keys)
+            if result == ReadResult.GATEWAY_NOT_READY:
+                return False, "gateway_not_ready"
+            return True, None
         except (ModbusException, ConnectionException, OSError):
-            return False
+            return False, "cannot_connect"
         finally:
             if api_client.connected:
                 await api_client.close()
@@ -256,7 +267,13 @@ class AtwMbs02ConfigProvider:
             try:
                 if not await api_client.connect():
                     return None
-                await api_client.read_values(api_client.register_map.gateway_keys)
+                result = await api_client.read_values(
+                    api_client.register_map.gateway_keys
+                )
+                if result != ReadResult.SUCCESS:
+                    # Gateway is reachable but not ready — skip auto-detect;
+                    # the user can still pick the variant manually.
+                    return None
                 unit_model = await api_client.read_value("unit_model")
                 if unit_model is not None and unit_model != "unknown":
                     _LOGGER.debug(
@@ -301,7 +318,11 @@ class AtwMbs02ConfigProvider:
 
             _LOGGER.debug("Fetching all values to allow profiles to detect device")
             keys_to_read = api_client.register_map.base_keys
-            await api_client.read_values(keys_to_read)
+            result = await api_client.read_values(keys_to_read)
+            if result == ReadResult.GATEWAY_NOT_READY:
+                # _data is not populated; trying to decode would yield None
+                # values and crash. Surface a user-facing error instead.
+                return [], "gateway_not_ready"
             all_data = {key: await api_client.read_value(key) for key in keys_to_read}
 
             decoded_data = api_client.decode_config(all_data)

--- a/custom_components/hitachi_yutaki/api/config_providers/hc_a_mb.py
+++ b/custom_components/hitachi_yutaki/api/config_providers/hc_a_mb.py
@@ -30,6 +30,7 @@ from ...const import (
 )
 from ...profiles import PROFILES
 from .. import GATEWAY_INFO, create_register_map
+from ..base import ReadResult
 from . import StepOutcome, StepSchema
 
 _LOGGER = logging.getLogger(__name__)
@@ -119,7 +120,11 @@ class HcAMbConfigProvider:
 
             # Read base keys for profile detection
             keys_to_read = api_client.register_map.base_keys
-            await api_client.read_values(keys_to_read)
+            result = await api_client.read_values(keys_to_read)
+            if result == ReadResult.GATEWAY_NOT_READY:
+                # _data is not populated; trying to decode would yield None
+                # values and crash. Surface a user-facing error instead.
+                return StepOutcome(errors={"base": "gateway_not_ready"})
             all_data = {key: await api_client.read_value(key) for key in keys_to_read}
 
             # Decode raw config to get boolean flags for profile detection

--- a/custom_components/hitachi_yutaki/api/modbus/__init__.py
+++ b/custom_components/hitachi_yutaki/api/modbus/__init__.py
@@ -270,8 +270,14 @@ class ModbusApiClient(HitachiApiClient):
         return bool(system_config & self._register_map.mask_pool)
 
     def decode_config(self, data: dict[str, Any]) -> dict[str, Any]:
-        """Decode raw config data into a dictionary of boolean flags."""
-        system_config = data.get("system_config", 0)
+        """Decode raw config data into a dictionary of boolean flags.
+
+        Defensive: treats a missing or ``None`` ``system_config`` as ``0``
+        (no modules detected) instead of raising ``TypeError``. Callers should
+        still avoid passing unread data (see :class:`ReadResult` contract).
+        """
+        # `or 0` (not the dict default) so a None value also falls back to 0.
+        system_config = data.get("system_config") or 0
         rmap = self._register_map
         decoded = data.copy()
         decoded["has_dhw"] = bool(system_config & rmap.mask_dhw)
@@ -350,7 +356,15 @@ class ModbusApiClient(HitachiApiClient):
         return value
 
     async def read_values(self, keys: list[str]) -> ReadResult:
-        """Fetch data from the heat pump for the given keys."""
+        """Fetch data from the heat pump for the given keys.
+
+        Always performs a preflight read of ``system_state``. If the gateway
+        reports an unhealthy state (initializing or desynchronized), returns
+        ``ReadResult.GATEWAY_NOT_READY`` WITHOUT reading any of the requested
+        keys — only ``system_state`` is populated in ``_data``. Callers must
+        check the return value before consuming ``read_value()`` output. See
+        :class:`ReadResult` for the full contract.
+        """
         retry_count = 0
         max_read_retries = 1  # Only retry once after reconnection
 

--- a/custom_components/hitachi_yutaki/translations/en.json
+++ b/custom_components/hitachi_yutaki/translations/en.json
@@ -208,7 +208,7 @@
       "unknown": "An unknown error occurred. Please check the logs.",
       "system_initializing": "The Hitachi Yutaki gateway is initializing. Please wait a moment and try again.",
       "desync_error": "The gateway is out of sync with the heat pump. Ensure the heat pump is powered on and the connection between the two devices is correct.",
-      "gateway_not_ready": "The gateway is reachable but not ready (still initializing, or out of sync with the heat pump). This is normal for a few minutes right after powering on the gateway. If it persists, see the troubleshooting guide: https://github.com/alepee/hass-hitachi_yutaki/blob/main/docs/troubleshooting.md"
+      "gateway_not_ready": "The gateway is reachable but not ready (still initializing, or out of sync with the heat pump). This is normal for a few minutes right after powering on the gateway. If it persists, check the H-LINK wiring (terminals 1-2 on the indoor unit PCB, 0.75 mm² shielded twisted pair) and see the project's troubleshooting guide."
     },
     "abort": {
       "already_configured": "This Hitachi Yutaki gateway is already configured.",

--- a/custom_components/hitachi_yutaki/translations/en.json
+++ b/custom_components/hitachi_yutaki/translations/en.json
@@ -207,7 +207,8 @@
       "invalid_central_control_mode": "The gateway must be in 'Central' control mode. Please change it in the gateway settings.",
       "unknown": "An unknown error occurred. Please check the logs.",
       "system_initializing": "The Hitachi Yutaki gateway is initializing. Please wait a moment and try again.",
-      "desync_error": "The gateway is out of sync with the heat pump. Ensure the heat pump is powered on and the connection between the two devices is correct."
+      "desync_error": "The gateway is out of sync with the heat pump. Ensure the heat pump is powered on and the connection between the two devices is correct.",
+      "gateway_not_ready": "The gateway is reachable but not ready (still initializing, or out of sync with the heat pump). This is normal for a minute or two right after powering on the gateway. If it has been powered on for longer than that, check: (1) the indoor unit is powered on, (2) the H-LINK wires between the gateway and the indoor unit are correctly connected and not damaged, (3) the H-LINK address (DIP switches) on the gateway is set correctly. Wait a few minutes and try again."
     },
     "abort": {
       "already_configured": "This Hitachi Yutaki gateway is already configured.",

--- a/custom_components/hitachi_yutaki/translations/en.json
+++ b/custom_components/hitachi_yutaki/translations/en.json
@@ -208,7 +208,7 @@
       "unknown": "An unknown error occurred. Please check the logs.",
       "system_initializing": "The Hitachi Yutaki gateway is initializing. Please wait a moment and try again.",
       "desync_error": "The gateway is out of sync with the heat pump. Ensure the heat pump is powered on and the connection between the two devices is correct.",
-      "gateway_not_ready": "The gateway is reachable but not ready (still initializing, or out of sync with the heat pump). This is normal for a minute or two right after powering on the gateway. If it has been powered on for longer than that, check: (1) the indoor unit is powered on, (2) the H-LINK wires between the gateway and the indoor unit are correctly connected and not damaged, (3) the H-LINK address (DIP switches) on the gateway is set correctly. Wait a few minutes and try again."
+      "gateway_not_ready": "The gateway is reachable but not ready (still initializing, or out of sync with the heat pump). This is normal for a few minutes right after powering on the gateway. If it persists, see the troubleshooting guide: https://github.com/alepee/hass-hitachi_yutaki/blob/main/docs/troubleshooting.md"
     },
     "abort": {
       "already_configured": "This Hitachi Yutaki gateway is already configured.",

--- a/custom_components/hitachi_yutaki/translations/fr.json
+++ b/custom_components/hitachi_yutaki/translations/fr.json
@@ -207,7 +207,8 @@
       "invalid_central_control_mode": "La passerelle doit être en mode de contrôle 'Central'. Veuillez modifier ce paramètre dans les réglages de la passerelle.",
       "unknown": "Une erreur inconnue s'est produite. Veuillez consulter les journaux.",
       "system_initializing": "La passerelle Hitachi Yutaki est en cours d'initialisation. Veuillez patienter quelques instants et réessayer.",
-      "desync_error": "La passerelle est désynchronisée de la pompe à chaleur. Assurez-vous que la pompe à chaleur est sous tension et que la connexion entre les deux appareils est correcte."
+      "desync_error": "La passerelle est désynchronisée de la pompe à chaleur. Assurez-vous que la pompe à chaleur est sous tension et que la connexion entre les deux appareils est correcte.",
+      "gateway_not_ready": "La passerelle est joignable mais n'est pas prête (en cours d'initialisation, ou désynchronisée de la pompe à chaleur). C'est normal pendant une à deux minutes après la mise sous tension de la passerelle. Si elle est allumée depuis plus longtemps, vérifiez : (1) que l'unité intérieure est sous tension, (2) que les câbles H-LINK entre la passerelle et l'unité intérieure sont correctement raccordés et non endommagés, (3) que l'adresse H-LINK (DIP switches) de la passerelle est correctement configurée. Patientez quelques minutes puis réessayez."
     },
     "abort": {
       "already_configured": "Cette passerelle Hitachi Yutaki est déjà configurée.",

--- a/custom_components/hitachi_yutaki/translations/fr.json
+++ b/custom_components/hitachi_yutaki/translations/fr.json
@@ -208,7 +208,7 @@
       "unknown": "Une erreur inconnue s'est produite. Veuillez consulter les journaux.",
       "system_initializing": "La passerelle Hitachi Yutaki est en cours d'initialisation. Veuillez patienter quelques instants et réessayer.",
       "desync_error": "La passerelle est désynchronisée de la pompe à chaleur. Assurez-vous que la pompe à chaleur est sous tension et que la connexion entre les deux appareils est correcte.",
-      "gateway_not_ready": "La passerelle est joignable mais n'est pas prête (en cours d'initialisation, ou désynchronisée de la pompe à chaleur). C'est normal pendant une à deux minutes après la mise sous tension de la passerelle. Si elle est allumée depuis plus longtemps, vérifiez : (1) que l'unité intérieure est sous tension, (2) que les câbles H-LINK entre la passerelle et l'unité intérieure sont correctement raccordés et non endommagés, (3) que l'adresse H-LINK (DIP switches) de la passerelle est correctement configurée. Patientez quelques minutes puis réessayez."
+      "gateway_not_ready": "La passerelle est joignable mais n'est pas prête (en cours d'initialisation, ou désynchronisée de la pompe à chaleur). C'est normal pendant quelques minutes après la mise sous tension de la passerelle. Si le problème persiste, consultez le guide de dépannage : https://github.com/alepee/hass-hitachi_yutaki/blob/main/docs/troubleshooting.md"
     },
     "abort": {
       "already_configured": "Cette passerelle Hitachi Yutaki est déjà configurée.",

--- a/custom_components/hitachi_yutaki/translations/fr.json
+++ b/custom_components/hitachi_yutaki/translations/fr.json
@@ -208,7 +208,7 @@
       "unknown": "Une erreur inconnue s'est produite. Veuillez consulter les journaux.",
       "system_initializing": "La passerelle Hitachi Yutaki est en cours d'initialisation. Veuillez patienter quelques instants et réessayer.",
       "desync_error": "La passerelle est désynchronisée de la pompe à chaleur. Assurez-vous que la pompe à chaleur est sous tension et que la connexion entre les deux appareils est correcte.",
-      "gateway_not_ready": "La passerelle est joignable mais n'est pas prête (en cours d'initialisation, ou désynchronisée de la pompe à chaleur). C'est normal pendant quelques minutes après la mise sous tension de la passerelle. Si le problème persiste, consultez le guide de dépannage : https://github.com/alepee/hass-hitachi_yutaki/blob/main/docs/troubleshooting.md"
+      "gateway_not_ready": "La passerelle est joignable mais n'est pas prête (en cours d'initialisation, ou désynchronisée de la pompe à chaleur). C'est normal pendant quelques minutes après la mise sous tension de la passerelle. Si le problème persiste, vérifiez le câblage H-LINK (bornes 1-2 sur le PCB de l'unité intérieure, paire torsadée blindée 0.75 mm²) et consultez le guide de dépannage du projet."
     },
     "abort": {
       "already_configured": "Cette passerelle Hitachi Yutaki est déjà configurée.",

--- a/custom_components/hitachi_yutaki/translations/nl.json
+++ b/custom_components/hitachi_yutaki/translations/nl.json
@@ -207,7 +207,8 @@
       "invalid_central_control_mode": "De gateway moet in de 'Centraal' bedieningsmodus staan. Wijzig dit in de gatewayinstellingen.",
       "unknown": "Er is een onbekende fout opgetreden. Controleer de logboeken.",
       "system_initializing": "De Hitachi Yutaki gateway wordt geïnitialiseerd. Wacht even en probeer het opnieuw.",
-      "desync_error": "De gateway is niet gesynchroniseerd met de warmtepomp. Controleer of de warmtepomp is ingeschakeld en of de verbinding tussen beide apparaten correct is."
+      "desync_error": "De gateway is niet gesynchroniseerd met de warmtepomp. Controleer of de warmtepomp is ingeschakeld en of de verbinding tussen beide apparaten correct is.",
+      "gateway_not_ready": "De gateway is bereikbaar maar nog niet klaar (wordt nog geïnitialiseerd of is niet gesynchroniseerd met de warmtepomp). Dit is normaal gedurende enkele minuten na het inschakelen van de gateway. Als het probleem aanhoudt, raadpleeg de probleemoplossingsgids: https://github.com/alepee/hass-hitachi_yutaki/blob/main/docs/troubleshooting.md"
     },
     "abort": {
       "already_configured": "Deze Hitachi Yutaki gateway is al geconfigureerd.",

--- a/custom_components/hitachi_yutaki/translations/nl.json
+++ b/custom_components/hitachi_yutaki/translations/nl.json
@@ -208,7 +208,7 @@
       "unknown": "Er is een onbekende fout opgetreden. Controleer de logboeken.",
       "system_initializing": "De Hitachi Yutaki gateway wordt geïnitialiseerd. Wacht even en probeer het opnieuw.",
       "desync_error": "De gateway is niet gesynchroniseerd met de warmtepomp. Controleer of de warmtepomp is ingeschakeld en of de verbinding tussen beide apparaten correct is.",
-      "gateway_not_ready": "De gateway is bereikbaar maar nog niet klaar (wordt nog geïnitialiseerd of is niet gesynchroniseerd met de warmtepomp). Dit is normaal gedurende enkele minuten na het inschakelen van de gateway. Als het probleem aanhoudt, raadpleeg de probleemoplossingsgids: https://github.com/alepee/hass-hitachi_yutaki/blob/main/docs/troubleshooting.md"
+      "gateway_not_ready": "De gateway is bereikbaar maar nog niet klaar (wordt nog geïnitialiseerd of is niet gesynchroniseerd met de warmtepomp). Dit is normaal gedurende enkele minuten na het inschakelen van de gateway. Als het probleem aanhoudt, controleer de H-LINK bedrading (klemmen 1-2 op de PCB van de binnenunit, afgeschermde getwiste paar 0.75 mm²) en raadpleeg de probleemoplossingsgids van het project."
     },
     "abort": {
       "already_configured": "Deze Hitachi Yutaki gateway is al geconfigureerd.",

--- a/custom_components/hitachi_yutaki/translations/ro.json
+++ b/custom_components/hitachi_yutaki/translations/ro.json
@@ -207,7 +207,8 @@
       "invalid_central_control_mode": "Gateway-ul trebuie să fie în modul de control 'Central'. Modificați această setare în configurarea gateway-ului.",
       "unknown": "A apărut o eroare necunoscută. Consultați jurnalele.",
       "system_initializing": "Gateway-ul Hitachi Yutaki se inițializează. Așteptați un moment și încercați din nou.",
-      "desync_error": "Gateway-ul este desincronizat de pompa de căldură. Asigurați-vă că pompa de căldură este pornită și că legătura dintre cele două dispozitive este corectă."
+      "desync_error": "Gateway-ul este desincronizat de pompa de căldură. Asigurați-vă că pompa de căldură este pornită și că legătura dintre cele două dispozitive este corectă.",
+      "gateway_not_ready": "Gateway-ul este accesibil, dar nu este pregătit (încă se inițializează sau este desincronizat de pompa de căldură). Acest lucru este normal timp de câteva minute după pornirea gateway-ului. Dacă problema persistă, consultați ghidul de depanare: https://github.com/alepee/hass-hitachi_yutaki/blob/main/docs/troubleshooting.md"
     },
     "abort": {
       "already_configured": "Acest gateway Hitachi Yutaki este deja configurat.",

--- a/custom_components/hitachi_yutaki/translations/ro.json
+++ b/custom_components/hitachi_yutaki/translations/ro.json
@@ -208,7 +208,7 @@
       "unknown": "A apărut o eroare necunoscută. Consultați jurnalele.",
       "system_initializing": "Gateway-ul Hitachi Yutaki se inițializează. Așteptați un moment și încercați din nou.",
       "desync_error": "Gateway-ul este desincronizat de pompa de căldură. Asigurați-vă că pompa de căldură este pornită și că legătura dintre cele două dispozitive este corectă.",
-      "gateway_not_ready": "Gateway-ul este accesibil, dar nu este pregătit (încă se inițializează sau este desincronizat de pompa de căldură). Acest lucru este normal timp de câteva minute după pornirea gateway-ului. Dacă problema persistă, consultați ghidul de depanare: https://github.com/alepee/hass-hitachi_yutaki/blob/main/docs/troubleshooting.md"
+      "gateway_not_ready": "Gateway-ul este accesibil, dar nu este pregătit (încă se inițializează sau este desincronizat de pompa de căldură). Acest lucru este normal timp de câteva minute după pornirea gateway-ului. Dacă problema persistă, verificați cablajul H-LINK (bornele 1-2 pe PCB-ul unității interioare, pereche torsadată ecranată 0.75 mm²) și consultați ghidul de depanare al proiectului."
     },
     "abort": {
       "already_configured": "Acest gateway Hitachi Yutaki este deja configurat.",

--- a/tests/api/config_providers/test_atw_mbs_02.py
+++ b/tests/api/config_providers/test_atw_mbs_02.py
@@ -1,10 +1,38 @@
 """Tests for the ATW-MBS-02 gateway configuration provider."""
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 
+from custom_components.hitachi_yutaki.api.base import ReadResult
 from custom_components.hitachi_yutaki.api.config_providers.atw_mbs_02 import (
     AtwMbs02ConfigProvider,
 )
+
+
+def _make_mock_client(read_result: ReadResult) -> MagicMock:
+    """Build a fake API client whose read_values returns the given ReadResult."""
+    client = MagicMock()
+    client.connect = AsyncMock(return_value=True)
+    client.close = AsyncMock(return_value=True)
+    client.read_values = AsyncMock(return_value=read_result)
+    client.read_value = AsyncMock(return_value=None)
+    client.connected = True
+    client.register_map = MagicMock(
+        base_keys=["system_config", "system_state"],
+        gateway_keys=["unit_model", "system_state"],
+    )
+    return client
+
+
+def _patch_client_class(client: MagicMock):
+    """Patch GATEWAY_INFO so the provider instantiates `client` instead of the real class."""
+    info = MagicMock()
+    info.client_class = MagicMock(return_value=client)
+    return patch.dict(
+        "custom_components.hitachi_yutaki.api.config_providers.atw_mbs_02.GATEWAY_INFO",
+        {"modbus_atw_mbs_02": info},
+    )
 
 
 class TestAtwMbs02ConfigProvider:
@@ -62,3 +90,62 @@ class TestAtwMbs02ConfigProvider:
         """Verify step_schema raises ValueError for an unknown step ID."""
         with pytest.raises(ValueError, match="Unknown step_id"):
             self.provider.step_schema("invalid", {})
+
+
+@pytest.mark.asyncio
+class TestAtwMbs02GatewayNotReady:
+    """Regression: provider must not crash when gateway is initializing/desynced.
+
+    Before the fix, read_values returning GATEWAY_NOT_READY left _data empty,
+    read_value returned None for every key, and decode_config crashed with
+    `TypeError: unsupported operand type(s) for &: 'NoneType' and 'int'`.
+    """
+
+    async def test_detect_profiles_returns_gateway_not_ready(self) -> None:
+        """_detect_profiles must surface gateway_not_ready, not crash."""
+        client = _make_mock_client(ReadResult.GATEWAY_NOT_READY)
+        with _patch_client_class(client):
+            detected, error = await AtwMbs02ConfigProvider._detect_profiles(
+                hass=MagicMock(),
+                context={
+                    "name": "test",
+                    "modbus_host": "127.0.0.1",
+                    "modbus_port": 502,
+                    "modbus_device_id": 1,
+                },
+                variant="gen2",
+            )
+        assert detected == []
+        assert error == "gateway_not_ready"
+        client.read_value.assert_not_called()  # short-circuit before decode
+
+    async def test_test_connection_returns_gateway_not_ready(self) -> None:
+        """_test_connection must distinguish gateway_not_ready from cannot_connect."""
+        client = _make_mock_client(ReadResult.GATEWAY_NOT_READY)
+        with _patch_client_class(client):
+            ok, error = await AtwMbs02ConfigProvider._test_connection(
+                hass=MagicMock(),
+                config={
+                    "name": "test",
+                    "modbus_host": "127.0.0.1",
+                    "modbus_port": 502,
+                    "modbus_device_id": 1,
+                },
+            )
+        assert ok is False
+        assert error == "gateway_not_ready"
+
+    async def test_detect_variant_returns_none_when_gateway_not_ready(self) -> None:
+        """_detect_variant must skip auto-detect when gateway is not ready."""
+        client = _make_mock_client(ReadResult.GATEWAY_NOT_READY)
+        with _patch_client_class(client):
+            variant = await AtwMbs02ConfigProvider._detect_variant(
+                hass=MagicMock(),
+                config={
+                    "modbus_host": "127.0.0.1",
+                    "modbus_port": 502,
+                    "modbus_device_id": 1,
+                },
+            )
+        assert variant is None
+        client.read_value.assert_not_called()

--- a/tests/api/config_providers/test_hc_a_mb.py
+++ b/tests/api/config_providers/test_hc_a_mb.py
@@ -1,5 +1,10 @@
 """Tests for the HC-A-MB gateway configuration provider."""
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.hitachi_yutaki.api.base import ReadResult
 from custom_components.hitachi_yutaki.api.config_providers.hc_a_mb import (
     HcAMbConfigProvider,
 )
@@ -31,3 +36,47 @@ class TestHcAMbConfigProvider:
         assert "modbus_device_id" in schema_keys
         assert "scan_interval" in schema_keys
         assert "name" in schema_keys
+
+
+@pytest.mark.asyncio
+class TestHcAMbGatewayNotReady:
+    """Regression: process_step must surface gateway_not_ready instead of crashing.
+
+    Same root cause as ATW-MBS-02: read_values returning GATEWAY_NOT_READY
+    leaves _data empty, decode_config(None) would crash.
+    """
+
+    async def test_process_step_returns_gateway_not_ready(self) -> None:
+        """process_step must return an error outcome when gateway is not ready."""
+        client = MagicMock()
+        client.connect = AsyncMock(return_value=True)
+        client.close = AsyncMock(return_value=True)
+        client.read_values = AsyncMock(return_value=ReadResult.GATEWAY_NOT_READY)
+        client.read_value = AsyncMock(return_value=None)
+        client.connected = True
+        client.register_map = MagicMock(base_keys=["system_config", "system_state"])
+
+        info = MagicMock()
+        info.client_class = MagicMock(return_value=client)
+
+        provider = HcAMbConfigProvider()
+        with patch.dict(
+            "custom_components.hitachi_yutaki.api.config_providers.hc_a_mb.GATEWAY_INFO",
+            {"modbus_hc_a_mb": info},
+        ):
+            outcome = await provider.process_step(
+                hass=MagicMock(),
+                step_id="hc_a_mb_connection",
+                user_input={
+                    "name": "test",
+                    "modbus_host": "127.0.0.1",
+                    "modbus_port": 502,
+                    "modbus_device_id": 1,
+                    "unit_id": 0,
+                },
+                context={},
+            )
+
+        assert outcome.errors == {"base": "gateway_not_ready"}
+        assert outcome.detected_profiles is None or outcome.detected_profiles == []
+        client.read_value.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes #300 — the config flow crashes with `TypeError` when the ATW-MBS-02 or HC-A(16/64)MB gateway reports an unhealthy `system_state` (1 = desynchronized, 2 = initializing) during integration setup. Now surfaces a clear, actionable error.

## Root cause

Regression introduced in 2.1.0-beta.2 (#260): `read_values()` was changed to short-circuit on unhealthy `system_state` and return `ReadResult.GATEWAY_NOT_READY` **without populating `_data`**. The coordinator was updated to handle this enum, but the two config providers (`atw_mbs_02.py`, `hc_a_mb.py`) continued to ignore the return value and call `read_value(k)` immediately afterwards — which returned `None` for every key. `decode_config` then crashed on `bool(None & rmap.mask_dhw)`.

Why this is the first report (despite the regression being shipped in late March):
- Before #260, the same gateway state did not crash — it just yielded a silently incorrect profile detection (no `TypeError`).
- Hitting it requires the gateway to be in initializing/desync state at the exact moment of config flow. Most users install + verify the gateway with other tooling before configuring HA, so the gateway is already `SUCCESS` by then.
- The reporter (`leandresz`) appears to have powered the gateway just before configuration; the initializing state can also persist (~50min) when the H-LINK link is misconfigured (#254).

## Changes

- **`ReadResult` contract** documented explicitly: callers MUST inspect the return before consuming `read_value()` output. `GATEWAY_NOT_READY` means `_data` is NOT populated.
- **ATW-MBS-02 provider** (`atw_mbs_02.py`):
  - `_test_connection` now returns `tuple[bool, str | None]` to distinguish `gateway_not_ready` from `cannot_connect`.
  - `_detect_variant` short-circuits and falls back to manual variant selection when not ready.
  - `_detect_profiles` returns `gateway_not_ready` error instead of crashing.
- **HC-A(16/64)MB provider** (`hc_a_mb.py`): same check in `process_step`.
- **i18n** (`en.json`, `fr.json`): new `gateway_not_ready` error with a rich, actionable message:
  > The gateway is reachable but not ready (still initializing, or out of sync with the heat pump). This is normal for a minute or two right after powering on the gateway. If it has been powered on for longer than that, check: (1) the indoor unit is powered on, (2) the H-LINK wires between the gateway and the indoor unit are correctly connected and not damaged, (3) the H-LINK address (DIP switches) on the gateway is set correctly. Wait a few minutes and try again.
- **Defense-in-depth** in `decode_config`: treats missing/`None` `system_config` as `0` instead of raising, so a future contract violation degrades gracefully.

## Tests

4 new tests (3 ATW + 1 HC-A) covering the `GATEWAY_NOT_READY` paths — previously crashed with `TypeError`, now surface the user-friendly error.

- `make test` — 330 passed.
- `make check` — clean.

## Design notes

Considered factoring `_detect_profiles` / `_test_connection` / `_detect_variant` into a shared base class to prevent future "forgot to check the return" bugs. Decided against — the two providers already diverge (variant detection is ATW-only, future gateways may have entirely different flows). Premature factoring at n=2 would lock in a pattern that doesn't hold for n=3. The fix is local with a documented contract on `ReadResult` instead.

Closes #300
