### PR TITLE
fix(i18n): fill missing translations in options/reconfigure flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Options/reconfigure flow: fill missing translations in `translations/en.json` and `translations/fr.json` so the connection step shows translated error messages and field labels (`name`, `scan_interval`) instead of raw keys like `gateway_not_ready`. Both ATW-MBS-02 and HC-A(16/64)MB connection steps now mirror the initial setup flow (#302).
+
 ## [2.1.2] - 2026-05-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Options/reconfigure flow: fill missing translations in `translations/en.json` and `translations/fr.json` so the connection step shows translated error messages and field labels (`name`, `scan_interval`) instead of raw keys like `gateway_not_ready`. Both ATW-MBS-02 and HC-A(16/64)MB connection steps now mirror the initial setup flow (#302).
+- Options/reconfigure flow: fill missing translations in `translations/en.json`, `translations/fr.json`, `translations/nl.json` and `translations/ro.json` so the connection step shows translated error messages and field labels (`name`, `scan_interval`) instead of raw keys like `gateway_not_ready`. Both ATW-MBS-02 and HC-A(16/64)MB connection steps now mirror the initial setup flow (#302).
 
 ## [2.1.2] - 2026-05-28
 

--- a/custom_components/hitachi_yutaki/translations/en.json
+++ b/custom_components/hitachi_yutaki/translations/en.json
@@ -82,19 +82,23 @@
         "title": "Connection Settings",
         "description": "Enter the connection details for your Hitachi Yutaki heat pump gateway.",
         "data": {
+          "name": "Name",
           "modbus_host": "Host/IP Address",
           "modbus_port": "Port",
-          "modbus_device_id": "Modbus Device ID"
+          "modbus_device_id": "Modbus Device ID",
+          "scan_interval": "Polling Interval (seconds)"
         }
       },
       "hc_a_mb_connection": {
         "title": "Connection Settings",
         "description": "Enter the connection details for your Hitachi Yutaki heat pump gateway.",
         "data": {
+          "name": "Name",
           "modbus_host": "Host/IP Address",
           "modbus_port": "Port",
           "modbus_device_id": "Modbus Device ID",
-          "unit_id": "Unit ID"
+          "unit_id": "Unit ID",
+          "scan_interval": "Polling Interval (seconds)"
         }
       },
       "profile": {
@@ -135,6 +139,16 @@
           "telemetry_level": "Anonymous telemetry"
         }
       }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect to the gateway. Please check the host and port.",
+      "invalid_slave": "Invalid Modbus slave ID. Please check the ID and try again.",
+      "modbus_error": "A Modbus error occurred. Check the logs for more details.",
+      "invalid_central_control_mode": "The gateway must be in 'Central' control mode. Please change it in the gateway settings.",
+      "unknown": "An unknown error occurred. Please check the logs.",
+      "system_initializing": "The Hitachi Yutaki gateway is initializing. Please wait a moment and try again.",
+      "desync_error": "The gateway is out of sync with the heat pump. Ensure the heat pump is powered on and the connection between the two devices is correct.",
+      "gateway_not_ready": "The gateway is reachable but not ready (still initializing, or out of sync with the heat pump). This is normal for a few minutes right after powering on the gateway. If it persists, check the H-LINK wiring (terminals 1-2 on the indoor unit PCB, 0.75 mm² shielded twisted pair) and see the project's troubleshooting guide."
     }
   },
   "config": {

--- a/custom_components/hitachi_yutaki/translations/fr.json
+++ b/custom_components/hitachi_yutaki/translations/fr.json
@@ -80,21 +80,25 @@
       },
       "atw_mbs_02_connection": {
         "title": "Paramètres de connexion",
-        "description": "Entrez les détails de connexion pour votre passerelle.",
+        "description": "Entrez les détails de connexion pour votre passerelle de pompe à chaleur Hitachi Yutaki.",
         "data": {
+          "name": "Nom",
           "modbus_host": "Hôte/Adresse IP",
           "modbus_port": "Port",
-          "modbus_device_id": "ID Périphérique Modbus"
+          "modbus_device_id": "ID Périphérique Modbus",
+          "scan_interval": "Intervalle d'interrogation (secondes)"
         }
       },
       "hc_a_mb_connection": {
         "title": "Paramètres de connexion",
-        "description": "Entrez les détails de connexion pour votre passerelle.",
+        "description": "Entrez les détails de connexion pour votre passerelle de pompe à chaleur Hitachi Yutaki.",
         "data": {
+          "name": "Nom",
           "modbus_host": "Hôte/Adresse IP",
           "modbus_port": "Port",
           "modbus_device_id": "ID Périphérique Modbus",
-          "unit_id": "Identifiant d'unité"
+          "unit_id": "Identifiant d'unité",
+          "scan_interval": "Intervalle d'interrogation (secondes)"
         }
       },
       "profile": {
@@ -135,6 +139,16 @@
           "telemetry_level": "Télémétrie anonyme"
         }
       }
+    },
+    "error": {
+      "cannot_connect": "Échec de la connexion à la passerelle. Veuillez vérifier l'hôte et le port.",
+      "invalid_slave": "ID d'esclave Modbus invalide. Veuillez vérifier l'ID et réessayer.",
+      "modbus_error": "Une erreur Modbus s'est produite. Consultez les journaux pour plus de détails.",
+      "invalid_central_control_mode": "La passerelle doit être en mode de contrôle 'Central'. Veuillez modifier ce paramètre dans les réglages de la passerelle.",
+      "unknown": "Une erreur inconnue s'est produite. Veuillez consulter les journaux.",
+      "system_initializing": "La passerelle Hitachi Yutaki est en cours d'initialisation. Veuillez patienter quelques instants et réessayer.",
+      "desync_error": "La passerelle est désynchronisée de la pompe à chaleur. Assurez-vous que la pompe à chaleur est sous tension et que la connexion entre les deux appareils est correcte.",
+      "gateway_not_ready": "La passerelle est joignable mais n'est pas prête (en cours d'initialisation, ou désynchronisée de la pompe à chaleur). C'est normal pendant quelques minutes après la mise sous tension de la passerelle. Si le problème persiste, vérifiez le câblage H-LINK (bornes 1-2 sur le PCB de l'unité intérieure, paire torsadée blindée 0.75 mm²) et consultez le guide de dépannage du projet."
     }
   },
   "config": {

--- a/custom_components/hitachi_yutaki/translations/nl.json
+++ b/custom_components/hitachi_yutaki/translations/nl.json
@@ -80,21 +80,25 @@
       },
       "atw_mbs_02_connection": {
         "title": "Verbindingsinstellingen",
-        "description": "Voer de verbindingsgegevens in voor uw gateway.",
+        "description": "Voer de verbindingsgegevens in voor uw Hitachi Yutaki warmtepompgateway.",
         "data": {
+          "name": "Naam",
           "modbus_host": "Host/IP-adres",
           "modbus_port": "Poort",
-          "modbus_device_id": "Modbus Apparaat-ID"
+          "modbus_device_id": "Modbus Apparaat-ID",
+          "scan_interval": "Polling-interval (seconden)"
         }
       },
       "hc_a_mb_connection": {
         "title": "Verbindingsinstellingen",
-        "description": "Voer de verbindingsgegevens in voor uw gateway.",
+        "description": "Voer de verbindingsgegevens in voor uw Hitachi Yutaki warmtepompgateway.",
         "data": {
+          "name": "Naam",
           "modbus_host": "Host/IP-adres",
           "modbus_port": "Poort",
           "modbus_device_id": "Modbus Apparaat-ID",
-          "unit_id": "Unit ID"
+          "unit_id": "Unit ID",
+          "scan_interval": "Polling-interval (seconden)"
         }
       },
       "profile": {
@@ -135,6 +139,16 @@
           "telemetry_level": "Anonieme telemetrie"
         }
       }
+    },
+    "error": {
+      "cannot_connect": "Kan geen verbinding maken met de gateway. Controleer de host en poort.",
+      "invalid_slave": "Ongeldig Modbus slave-ID. Controleer het ID en probeer het opnieuw.",
+      "modbus_error": "Er is een Modbus-fout opgetreden. Controleer de logboeken voor meer informatie.",
+      "invalid_central_control_mode": "De gateway moet in de 'Centraal' bedieningsmodus staan. Wijzig dit in de gatewayinstellingen.",
+      "unknown": "Er is een onbekende fout opgetreden. Controleer de logboeken.",
+      "system_initializing": "De Hitachi Yutaki gateway wordt geïnitialiseerd. Wacht even en probeer het opnieuw.",
+      "desync_error": "De gateway is niet gesynchroniseerd met de warmtepomp. Controleer of de warmtepomp is ingeschakeld en of de verbinding tussen beide apparaten correct is.",
+      "gateway_not_ready": "De gateway is bereikbaar maar nog niet klaar (wordt nog geïnitialiseerd of is niet gesynchroniseerd met de warmtepomp). Dit is normaal gedurende enkele minuten na het inschakelen van de gateway. Als het probleem aanhoudt, controleer de H-LINK bedrading (klemmen 1-2 op de PCB van de binnenunit, afgeschermde getwiste paar 0.75 mm²) en raadpleeg de probleemoplossingsgids van het project."
     }
   },
   "config": {

--- a/custom_components/hitachi_yutaki/translations/ro.json
+++ b/custom_components/hitachi_yutaki/translations/ro.json
@@ -80,21 +80,25 @@
       },
       "atw_mbs_02_connection": {
         "title": "Setări de conexiune",
-        "description": "Introduceți detaliile de conexiune pentru gateway-ul dumneavoastră.",
+        "description": "Introduceți detaliile de conexiune pentru gateway-ul pompei de căldură Hitachi Yutaki.",
         "data": {
+          "name": "Nume",
           "modbus_host": "Gazdă/Adresă IP",
           "modbus_port": "Port",
-          "modbus_device_id": "ID Dispozitiv Modbus"
+          "modbus_device_id": "ID Dispozitiv Modbus",
+          "scan_interval": "Interval de interogare (secunde)"
         }
       },
       "hc_a_mb_connection": {
         "title": "Setări de conexiune",
-        "description": "Introduceți detaliile de conexiune pentru gateway-ul dumneavoastră.",
+        "description": "Introduceți detaliile de conexiune pentru gateway-ul pompei de căldură Hitachi Yutaki.",
         "data": {
+          "name": "Nume",
           "modbus_host": "Gazdă/Adresă IP",
           "modbus_port": "Port",
           "modbus_device_id": "ID Dispozitiv Modbus",
-          "unit_id": "ID unitate"
+          "unit_id": "ID unitate",
+          "scan_interval": "Interval de interogare (secunde)"
         }
       },
       "profile": {
@@ -135,6 +139,16 @@
           "telemetry_level": "Telemetrie anonimă"
         }
       }
+    },
+    "error": {
+      "cannot_connect": "Nu s-a putut conecta la gateway. Verificați gazda și portul.",
+      "invalid_slave": "ID slave Modbus invalid. Verificați ID-ul și încercați din nou.",
+      "modbus_error": "A apărut o eroare Modbus. Consultați jurnalele pentru mai multe detalii.",
+      "invalid_central_control_mode": "Gateway-ul trebuie să fie în modul de control 'Central'. Modificați această setare în configurarea gateway-ului.",
+      "unknown": "A apărut o eroare necunoscută. Consultați jurnalele.",
+      "system_initializing": "Gateway-ul Hitachi Yutaki se inițializează. Așteptați un moment și încercați din nou.",
+      "desync_error": "Gateway-ul este desincronizat de pompa de căldură. Asigurați-vă că pompa de căldură este pornită și că legătura dintre cele două dispozitive este corectă.",
+      "gateway_not_ready": "Gateway-ul este accesibil, dar nu este pregătit (încă se inițializează sau este desincronizat de pompa de căldură). Acest lucru este normal timp de câteva minute după pornirea gateway-ului. Dacă problema persistă, verificați cablajul H-LINK (bornele 1-2 pe PCB-ul unității interioare, pereche torsadată ecranată 0.75 mm²) și consultați ghidul de depanare al proiectului."
     }
   },
   "config": {


### PR DESCRIPTION
## Summary

Fix raw translation keys (`gateway_not_ready`, `name`, `scan_interval`) leaking through the options/reconfigure flow connection step. Mirrors the missing entries from the `config` block into the `options` block in both `translations/en.json` (source of truth) and `translations/fr.json`.

## Root cause

In `translations/en.json`:
- `options.error` was empty, so all error keys fell back to raw.
- `options.step.atw_mbs_02_connection.data` was missing `name` and `scan_interval`.
- Same gaps applied to `options.step.hc_a_mb_connection`.

`fr.json` mirrored those gaps (and had a shorter description for both connection steps).

## Fix

- `translations/en.json`: add `options.error` (cannot_connect, invalid_slave, modbus_error, invalid_central_control_mode, unknown, system_initializing, desync_error, gateway_not_ready), and add `name` + `scan_interval` to `options.step.atw_mbs_02_connection.data` and `options.step.hc_a_mb_connection.data`.
- `translations/fr.json`: same additions plus aligned the two connection-step descriptions with the config side wording.
- Other languages (`nl.json`, `ro.json`) will pick up the new keys via Weblate.

## Test plan

- [x] `python3 -m json.tool` validates both `en.json` and `fr.json`.
- [x] `make check` passes.
- [x] `make test` passes (330 tests).
- [ ] Reconfigure an existing ATW-MBS-02 entry with a wrong IP: translated error text appears, not the raw key.
- [ ] All connection-step fields (`name`, `host`, `port`, `device_id`, `scan_interval`) show translated labels.
- [ ] Same checks pass for HC-A(16/64)MB.

Closes #302