### PR TITLE
feat(config-flow): preserve user input on validation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Options/reconfigure flow: fill missing translations in `translations/en.json`, `translations/fr.json`, `translations/nl.json` and `translations/ro.json` so the connection step shows translated error messages and field labels (`name`, `scan_interval`) instead of raw keys like `gateway_not_ready`. Both ATW-MBS-02 and HC-A(16/64)MB connection steps now mirror the initial setup flow (#302).
 
+### Changed
+- Config flow: preserve user-typed values (host, port, slave, name, scan interval, gateway variant) when a provider step fails validation (`cannot_connect`, `gateway_not_ready`, `invalid_slave`, ...). Applies to both initial setup and reconfigure/options flows, for ATW-MBS-02 and HC-A(16/64)MB providers. Previously, fields were reset to defaults on every retry (#304).
+
 ## [2.1.2] - 2026-05-28
 
 ### Fixed

--- a/custom_components/hitachi_yutaki/config_flow.py
+++ b/custom_components/hitachi_yutaki/config_flow.py
@@ -202,9 +202,15 @@ class HitachiYutakiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             if outcome.errors:
                 step_schema = self._provider.step_schema(step_id, self._step_context)
+                # Preserve user-typed values (host/port/slave/...) so the
+                # user doesn't have to re-enter them on every validation
+                # error. See issue #304.
+                data_schema = self.add_suggested_values_to_schema(
+                    step_schema.schema, user_input
+                )
                 return self.async_show_form(
                     step_id=step_id,
-                    data_schema=step_schema.schema,
+                    data_schema=data_schema,
                     description_placeholders=step_schema.description_placeholders,
                     errors=outcome.errors,
                 )
@@ -457,9 +463,15 @@ class HitachiYutakiOptionsFlow(config_entries.OptionsFlow):
 
             if outcome.errors:
                 step_schema = self._provider.step_schema(step_id, self._step_context)
+                # Preserve user-typed values (host/port/slave/...) so the
+                # user doesn't have to re-enter them on every validation
+                # error. See issue #304.
+                data_schema = self.add_suggested_values_to_schema(
+                    step_schema.schema, user_input
+                )
                 return self.async_show_form(
                     step_id=step_id,
-                    data_schema=step_schema.schema,
+                    data_schema=data_schema,
                     description_placeholders=step_schema.description_placeholders,
                     errors=outcome.errors,
                 )

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -196,6 +196,116 @@ async def test_connection_failure(hass: HomeAssistant) -> None:
     assert result["errors"] == {"base": "cannot_connect"}
 
 
+def _suggested_values(schema) -> dict:
+    """Extract `suggested_value` for each key in a voluptuous Schema.
+
+    HA stores user-typed defaults in `key.description["suggested_value"]`
+    after `FlowHandler.add_suggested_values_to_schema()` is applied.
+    """
+    out: dict = {}
+    for key in schema.schema:
+        desc = getattr(key, "description", None)
+        if isinstance(desc, dict) and "suggested_value" in desc:
+            out[key.schema] = desc["suggested_value"]
+    return out
+
+
+async def test_connection_failure_preserves_user_input(hass: HomeAssistant) -> None:
+    """On connection failure, the form re-renders with the user-typed values.
+
+    Regression test for #304: host/port/slave/name typed by the user must
+    survive a validation error so they don't have to re-type on every retry.
+    """
+    result = await _advance_to_connection(hass)
+
+    mock_client = _mock_api_client()
+    mock_client.connect = AsyncMock(return_value=False)
+    mock_gw_info = _mock_gateway_info(mock_client)
+
+    typed = {
+        "name": "My Yutaki",
+        CONF_MODBUS_HOST: "10.20.30.40",
+        CONF_MODBUS_PORT: 1502,
+        CONF_MODBUS_DEVICE_ID: 7,
+        "scan_interval": DEFAULT_SCAN_INTERVAL,
+    }
+
+    with (
+        patch(_PATCH_ATW_GW_INFO, mock_gw_info),
+        patch(_PATCH_ATW_CREATE_RM),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], typed
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+    suggested = _suggested_values(result["data_schema"])
+    assert suggested.get("name") == "My Yutaki"
+    assert suggested.get(CONF_MODBUS_HOST) == "10.20.30.40"
+    assert suggested.get(CONF_MODBUS_PORT) == 1502
+    assert suggested.get(CONF_MODBUS_DEVICE_ID) == 7
+
+
+async def test_options_flow_connection_failure_preserves_user_input(
+    hass: HomeAssistant,
+) -> None:
+    """Options flow: connection failure preserves user-typed values (#304)."""
+    entry = MockConfigEntry(
+        version=2,
+        minor_version=4,
+        domain=DOMAIN,
+        title=DEFAULT_NAME,
+        data={
+            "gateway_type": "modbus_atw_mbs_02",
+            "gateway_variant": "gen2",
+            "name": DEFAULT_NAME,
+            CONF_MODBUS_HOST: DEFAULT_HOST,
+            CONF_MODBUS_PORT: DEFAULT_PORT,
+            CONF_MODBUS_DEVICE_ID: DEFAULT_DEVICE_ID,
+            "scan_interval": DEFAULT_SCAN_INTERVAL,
+            "profile": "yutaki_s",
+            "power_supply": DEFAULT_POWER_SUPPLY,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {"gateway_type": "modbus_atw_mbs_02"},
+    )
+    assert result["step_id"] == "atw_mbs_02_connection"
+
+    mock_client = _mock_api_client()
+    mock_client.connect = AsyncMock(return_value=False)
+    mock_gw_info = _mock_gateway_info(mock_client)
+
+    typed = {
+        "name": "Renamed Yutaki",
+        CONF_MODBUS_HOST: "10.20.30.40",
+        CONF_MODBUS_PORT: 1502,
+        CONF_MODBUS_DEVICE_ID: 9,
+        "scan_interval": DEFAULT_SCAN_INTERVAL,
+    }
+
+    with (
+        patch(_PATCH_ATW_GW_INFO, mock_gw_info),
+        patch(_PATCH_ATW_CREATE_RM),
+    ):
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], typed
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+    suggested = _suggested_values(result["data_schema"])
+    assert suggested.get("name") == "Renamed Yutaki"
+    assert suggested.get(CONF_MODBUS_HOST) == "10.20.30.40"
+    assert suggested.get(CONF_MODBUS_PORT) == 1502
+    assert suggested.get(CONF_MODBUS_DEVICE_ID) == 9
+
+
 async def test_connection_success_advances_to_variant(
     hass: HomeAssistant,
 ) -> None:


### PR DESCRIPTION
## Summary

When the gateway provider step fails validation (`cannot_connect`, `gateway_not_ready`, `invalid_slave`, decode error, ...), the form now re-renders with the user-typed values as suggested defaults instead of resetting host / port / slave / name to schema defaults. Especially helpful while iterating on a wiring or network problem.

Applies to both `HitachiYutakiConfigFlow` (initial setup) and `HitachiYutakiOptionsFlow` (reconfigure), and to both ATW-MBS-02 and HC-A(16/64)MB providers (the change is in the shared `_handle_provider_step` path).

## Root cause

`custom_components/hitachi_yutaki/config_flow.py`:
- `HitachiYutakiConfigFlow._handle_provider_step` (around line 198) re-rendered the form on the error path by calling `step_schema(step_id, context)` then `async_show_form(data_schema=step_schema.schema, ...)`. The provider's schema only knows about the persisted context, not the current submission, so freshly typed values were dropped.
- Same pattern in `HitachiYutakiOptionsFlow._handle_provider_step` (around line 458).

## Fix

Use `FlowHandler.add_suggested_values_to_schema(step_schema.schema, user_input)` on the error path before `async_show_form`, so each marker that matches a typed key gets `description={"suggested_value": ...}` and the frontend pre-fills it.

Minimal, behavior-preserving change confined to the error branch. GitNexus impact analysis on both methods returned LOW risk (direct callers are only the dynamically registered `handler` closures + `async_step_user`/`async_step_init` in the same file).

## Test plan

- [x] New test `test_connection_failure_preserves_user_input` (initial flow): submit `cannot_connect`, assert `errors == {"base": "cannot_connect"}` and that `name`, `host`, `port`, `slave` come back as `suggested_value` on the re-rendered schema.
- [x] New test `test_options_flow_connection_failure_preserves_user_input` (options flow): same coverage on the reconfigure path.
- [x] Existing `test_connection_failure` still passes (error key unchanged).
- [x] `make check` clean (ruff lint + format).
- [x] `make test` green (332 passed).

Closes #304