### PR TITLE
fix(init): tolerate gateway_not_ready on entry reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Options/reconfigure flow: fill missing translations in `translations/en.json`, `translations/fr.json`, `translations/nl.json` and `translations/ro.json` so the connection step shows translated error messages and field labels (`name`, `scan_interval`) instead of raw keys like `gateway_not_ready`. Both ATW-MBS-02 and HC-A(16/64)MB connection steps now mirror the initial setup flow (#302).
+- Setup: tolerate a transient `gateway_not_ready` (Modbus TCP up, H-LINK still initializing after a gateway power-cycle) during entry setup/reload. Previously a duplicate `async_config_entry_first_refresh()` call re-raised `ConfigEntryNotReady` and produced a "Setup failed, will retry" banner even though the gateway was simply in its H-LINK initialization window. Setup now completes; entities are `unavailable` until the next successful poll. Genuine connection failures (TCP unreachable, other Modbus errors) still raise `ConfigEntryNotReady` so HA's standard retry mechanism applies (#303).
 
 ### Changed
 - Config flow: preserve user-typed values (host, port, slave, name, scan interval, gateway variant) when a provider step fails validation (`cannot_connect`, `gateway_not_ready`, `invalid_slave`, ...). Applies to both initial setup and reconfigure/options flows, for ATW-MBS-02 and HC-A(16/64)MB providers. Previously, fields were reset to defaults on every retry (#304).

--- a/custom_components/hitachi_yutaki/__init__.py
+++ b/custom_components/hitachi_yutaki/__init__.py
@@ -71,6 +71,35 @@ _THERMAL_ENERGY_KEYS = (
 )
 
 
+async def _async_first_refresh_tolerating_gateway_not_ready(
+    coordinator: HitachiYutakiDataCoordinator,
+) -> bool:
+    """Run the coordinator's first refresh, tolerating a transient gateway-not-ready.
+
+    The ATW-MBS-02 gateway can report ``GATEWAY_NOT_READY`` while its H-LINK bus
+    is initializing after a power cycle (Modbus TCP is up, H-LINK is not). At
+    setup time this is a transient, expected condition: the entry was already
+    validated by the config flow, so we let setup complete and entities will
+    transition to ``available`` on the next successful poll. Any other cause
+    (TCP unreachable, Modbus error, etc.) is re-raised so HA retries setup.
+
+    Returns ``True`` when the refresh succeeded and fresh register data is
+    available, ``False`` when the refresh failed because of ``gateway_not_ready``
+    (callers must not assume ``coordinator.data`` reflects the current install).
+    """
+    try:
+        await coordinator.async_config_entry_first_refresh()
+    except ConfigEntryNotReady:
+        if coordinator.gateway_not_ready:
+            _LOGGER.warning(
+                "Gateway H-LINK is still initializing; continuing setup with "
+                "stale capabilities. Entities will recover on the next poll."
+            )
+            return False
+        raise
+    return True
+
+
 async def _async_restore_thermal_energy(
     hass: HomeAssistant,
     entry: HitachiYutakiConfigEntry,
@@ -301,20 +330,16 @@ async def async_setup_entry(
         supports_secondary_compressor=profile.supports_secondary_compressor,
     )
 
-    try:
-        await coordinator.async_config_entry_first_refresh()
-    except ConfigEntryNotReady:
-        _LOGGER.warning(
-            "Initial connection to Hitachi Yutaki failed. "
-            "The integration will retry in the background, and entities will be unavailable."
-        )
+    # Initial poll. A transient gateway_not_ready (H-LINK still initializing
+    # after a gateway power-cycle) must not fail setup of an already-configured
+    # entry: log a warning and continue. Entities will go ``available`` on the
+    # next successful poll. Any other ConfigEntryNotReady is re-raised so HA
+    # retries setup via its standard mechanism.
+    await _async_first_refresh_tolerating_gateway_not_ready(coordinator)
 
     _LOGGER.debug("Data coordinator initialized")
 
     entry.runtime_data = coordinator
-
-    # Wait for the first refresh to succeed before setting up platforms
-    await coordinator.async_config_entry_first_refresh()
 
     # Update COP services now that system_config is available
     coordinator.derived_metrics._has_cooling = coordinator.has_circuit(

--- a/custom_components/hitachi_yutaki/coordinator.py
+++ b/custom_components/hitachi_yutaki/coordinator.py
@@ -97,6 +97,16 @@ class HitachiYutakiDataCoordinator(DataUpdateCoordinator):
             return self.derived_metrics.defrost_guard
         return self._defrost_guard
 
+    @property
+    def gateway_not_ready(self) -> bool:
+        """Return True when the most recent poll hit GATEWAY_NOT_READY.
+
+        Set by ``_async_update_data`` and cleared on the first successful read.
+        Used by setup code to discriminate a transient H-LINK init window from
+        a genuine connectivity failure.
+        """
+        return self._gateway_not_ready_count > 0
+
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from Hitachi Yutaki."""
         try:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -137,3 +137,43 @@ async def test_coordinator_restores_interval_on_recovery(coordinator, mock_api_c
         await coordinator._async_update_data()
         assert coordinator.update_interval == normal
         assert coordinator._gateway_not_ready_count == 0
+
+
+@pytest.mark.asyncio
+async def test_gateway_not_ready_property_false_initially(coordinator):
+    """Initially the gateway is considered ready."""
+    assert coordinator.gateway_not_ready is False
+
+
+@pytest.mark.asyncio
+async def test_gateway_not_ready_property_true_after_gateway_not_ready(
+    coordinator, mock_api_client
+):
+    """Property reflects a recent gateway_not_ready result."""
+    mock_api_client.read_values.return_value = ReadResult.GATEWAY_NOT_READY
+
+    with (
+        patch("custom_components.hitachi_yutaki.coordinator.ir"),
+        pytest.raises(UpdateFailed),
+    ):
+        await coordinator._async_update_data()
+
+    assert coordinator.gateway_not_ready is True
+
+
+@pytest.mark.asyncio
+async def test_gateway_not_ready_property_false_after_recovery(
+    coordinator, mock_api_client
+):
+    """Property clears once the gateway poll succeeds again."""
+    mock_api_client.read_values.return_value = ReadResult.GATEWAY_NOT_READY
+
+    with patch("custom_components.hitachi_yutaki.coordinator.ir"):
+        with pytest.raises(UpdateFailed):  # noqa: SIM117
+            await coordinator._async_update_data()
+        assert coordinator.gateway_not_ready is True
+
+        mock_api_client.read_values.return_value = ReadResult.SUCCESS
+        await coordinator._async_update_data()
+
+    assert coordinator.gateway_not_ready is False

--- a/tests/test_init_first_refresh.py
+++ b/tests/test_init_first_refresh.py
@@ -1,0 +1,59 @@
+"""Tests for the setup-time first_refresh tolerance to gateway_not_ready.
+
+Covers issue #303: reloading the integration during the gateway's H-LINK
+initialization window must NOT fail setup. Other ``ConfigEntryNotReady``
+causes still propagate so HA retries setup normally.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.hitachi_yutaki import (
+    _async_first_refresh_tolerating_gateway_not_ready,
+)
+from homeassistant.exceptions import ConfigEntryNotReady
+
+
+@pytest.mark.asyncio
+async def test_first_refresh_success_returns_true():
+    """A normal successful first_refresh returns True (data is fresh)."""
+    coordinator = MagicMock()
+    coordinator.async_config_entry_first_refresh = AsyncMock(return_value=None)
+    coordinator.gateway_not_ready = False
+
+    result = await _async_first_refresh_tolerating_gateway_not_ready(coordinator)
+
+    assert result is True
+    coordinator.async_config_entry_first_refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_first_refresh_gateway_not_ready_swallows_and_returns_false():
+    """Gateway_not_ready raises ConfigEntryNotReady but setup continues."""
+    coordinator = MagicMock()
+    coordinator.async_config_entry_first_refresh = AsyncMock(
+        side_effect=ConfigEntryNotReady(
+            "Gateway is not ready (initializing or desynchronized)"
+        )
+    )
+    coordinator.gateway_not_ready = True
+
+    result = await _async_first_refresh_tolerating_gateway_not_ready(coordinator)
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_first_refresh_cannot_connect_reraises():
+    """A genuine connectivity failure still propagates ConfigEntryNotReady."""
+    coordinator = MagicMock()
+    coordinator.async_config_entry_first_refresh = AsyncMock(
+        side_effect=ConfigEntryNotReady("Failed to communicate with device")
+    )
+    coordinator.gateway_not_ready = False
+
+    with pytest.raises(ConfigEntryNotReady):
+        await _async_first_refresh_tolerating_gateway_not_ready(coordinator)


### PR DESCRIPTION
## Summary

Fixes #303. Reloading the integration during the ATW-MBS-02 gateway's H-LINK initialization window (Modbus TCP up, H-LINK not yet synchronized with the heat pump) was producing a `Setup failed, will retry: Gateway is not ready (initializing or desynchronized)` banner instead of completing setup with unavailable entities.

## Root cause

`async_setup_entry` in `custom_components/hitachi_yutaki/__init__.py` (lines 304-317 before the fix) called `coordinator.async_config_entry_first_refresh()` twice:

```python
try:
    await coordinator.async_config_entry_first_refresh()
except ConfigEntryNotReady:
    _LOGGER.warning("... will retry in the background ...")
...
await coordinator.async_config_entry_first_refresh()  # second call, no try/except
```

The first call's `try/except` was a no-op because the immediately following second call re-raised the same `ConfigEntryNotReady`. Refactor leftover.

## Fix

- Remove the duplicate `first_refresh` call.
- Add a `gateway_not_ready` property on the coordinator (backed by the existing `_gateway_not_ready_count`).
- Wrap the single `first_refresh` in `_async_first_refresh_tolerating_gateway_not_ready(coordinator)`:
  - On `ConfigEntryNotReady` caused by `gateway_not_ready`: log a warning, let setup complete. Entities are `unavailable` until the next successful poll.
  - On any other `ConfigEntryNotReady`: re-raise so HA's standard retry kicks in.
- Capability detection (circuits / DHW / pool) still runs against `system_config = 0` after a tolerated failure, which means those devices/entities lag by one reload cycle in the rare case where the user reloads inside the H-LINK init window. This is acceptable per the issue's acceptance criteria (entities transition to available on next poll).

## Test plan

- [x] `tests/test_coordinator.py` — new tests for the `gateway_not_ready` property (initial, after a `GATEWAY_NOT_READY` poll, after recovery).
- [x] `tests/test_init_first_refresh.py` — new tests for the setup helper:
  - success path returns `True`
  - `gateway_not_ready` cause is tolerated (returns `False`, no raise)
  - other `ConfigEntryNotReady` causes still propagate
- [x] `make check` passes (ruff clean).
- [x] `make test` passes (336 tests).
- [ ] Manual: power-cycle the ATW-MBS-02 gateway, reload integration within the H-LINK init window, observe setup completes and entities recover on next poll.
- [ ] Manual: stop the gateway (TCP unreachable), reload integration, observe HA shows the standard "Setup in progress, will retry" and recovers when the gateway is back.

Closes #303