### PR TITLE
feat(init): persist system capability flags in entry data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Config flow: preserve user-typed values (host, port, slave, name, scan interval, gateway variant) when a provider step fails validation (`cannot_connect`, `gateway_not_ready`, `invalid_slave`, ...). Applies to both initial setup and reconfigure/options flows, for ATW-MBS-02 and HC-A(16/64)MB providers. Previously, fields were reset to defaults on every retry (#304).
+- Persist the gateway `system_config` (capability bitfield) in the config entry data on every successful refresh. At setup time, COP services for cooling, DHW and pool are now initialised from this persisted value *before* the first refresh, so they survive a reload that hits `gateway_not_ready` during the gateway's H-LINK init window. Existing installations get the value populated on their next successful poll; until then the previous (post-refresh) behaviour applies as a fallback (#308).
 
 ## [2.1.2] - 2026-05-28
 

--- a/custom_components/hitachi_yutaki/__init__.py
+++ b/custom_components/hitachi_yutaki/__init__.py
@@ -319,14 +319,27 @@ async def async_setup_entry(
         "power_supply": entry.data.get(CONF_POWER_SUPPLY, DEFAULT_POWER_SUPPLY),
     }
 
+    # Seed capability flags from persisted system_config so COP services are
+    # initialised correctly even when the first refresh fails with
+    # gateway_not_ready (#308). decode_config tolerates missing/0 values and
+    # returns all-False flags for never-yet-refreshed entries.
+    persisted_flags = api_client.decode_config(
+        {"system_config": entry.data.get("system_config", 0)}
+    )
+    persisted_has_cooling = persisted_flags.get(
+        "has_circuit1_cooling", False
+    ) or persisted_flags.get("has_circuit2_cooling", False)
+    persisted_has_dhw = persisted_flags.get("has_dhw", False)
+    persisted_has_pool = persisted_flags.get("has_pool", False)
+
     # Create derived metrics adapter (enriches data with thermal power, COP, etc.)
     coordinator.derived_metrics = DerivedMetricsAdapter(
         hass=hass,
         config_entry=entry,
         power_supply=entry.data.get(CONF_POWER_SUPPLY, DEFAULT_POWER_SUPPLY),
-        has_cooling=False,  # updated after first refresh
-        has_dhw=False,  # updated after first refresh
-        has_pool=False,  # updated after first refresh
+        has_cooling=persisted_has_cooling,
+        has_dhw=persisted_has_dhw,
+        has_pool=persisted_has_pool,
         supports_secondary_compressor=profile.supports_secondary_compressor,
     )
 
@@ -341,15 +354,22 @@ async def async_setup_entry(
 
     entry.runtime_data = coordinator
 
-    # Update COP services now that system_config is available
-    coordinator.derived_metrics._has_cooling = coordinator.has_circuit(
-        CIRCUIT_PRIMARY_ID, CIRCUIT_MODE_COOLING
-    )
-    coordinator.derived_metrics._init_cop_services(
-        has_cooling=coordinator.has_circuit(CIRCUIT_PRIMARY_ID, CIRCUIT_MODE_COOLING),
-        has_dhw=coordinator.has_dhw(),
-        has_pool=coordinator.has_pool(),
-    )
+    # Re-initialise COP services if the live system_config disagrees with the
+    # persisted value (first-time setup, or capability changed on the unit).
+    live_has_cooling = coordinator.has_circuit(CIRCUIT_PRIMARY_ID, CIRCUIT_MODE_COOLING)
+    live_has_dhw = coordinator.has_dhw()
+    live_has_pool = coordinator.has_pool()
+    if (
+        live_has_cooling != persisted_has_cooling
+        or live_has_dhw != persisted_has_dhw
+        or live_has_pool != persisted_has_pool
+    ):
+        coordinator.derived_metrics._has_cooling = live_has_cooling
+        coordinator.derived_metrics._init_cop_services(
+            has_cooling=live_has_cooling,
+            has_dhw=live_has_dhw,
+            has_pool=live_has_pool,
+        )
 
     # Restore thermal energy from last known state
     await _async_restore_thermal_energy(hass, entry, coordinator)

--- a/custom_components/hitachi_yutaki/api/config_providers/atw_mbs_02.py
+++ b/custom_components/hitachi_yutaki/api/config_providers/atw_mbs_02.py
@@ -180,12 +180,20 @@ class AtwMbs02ConfigProvider:
         """Detect profiles using the chosen variant."""
         variant = user_input["gateway_variant"]
 
-        detected_profiles, error = await self._detect_profiles(hass, context, variant)
+        detected_profiles, system_config, error = await self._detect_profiles(
+            hass, context, variant
+        )
         if error:
             return StepOutcome(errors={"base": error})
 
+        # Persist system_config so COP services and device capabilities can
+        # be initialised on next setup before any refresh (#308).
+        config_data: dict[str, Any] = {"gateway_variant": variant}
+        if system_config:
+            config_data["system_config"] = system_config
+
         return StepOutcome(
-            config_data={"gateway_variant": variant},
+            config_data=config_data,
             detected_profiles=detected_profiles,
         )
 
@@ -295,10 +303,13 @@ class AtwMbs02ConfigProvider:
         hass: HomeAssistant,
         context: dict[str, Any],
         variant: str,
-    ) -> tuple[list[str], str | None]:
+    ) -> tuple[list[str], int, str | None]:
         """Connect, read base_keys, decode config, and detect profiles.
 
-        Returns (detected_profiles, error_key). error_key is None on success.
+        Returns (detected_profiles, system_config, error_key). error_key is
+        None on success. ``system_config`` is the raw register value (0 on
+        error) so the config flow can persist it for early COP-service
+        initialisation on subsequent setups (#308).
         """
         api_client_class = GATEWAY_INFO[_GATEWAY_TYPE].client_class
         register_map = create_register_map(
@@ -314,7 +325,7 @@ class AtwMbs02ConfigProvider:
         )
         try:
             if not await api_client.connect():
-                return [], "cannot_connect"
+                return [], 0, "cannot_connect"
 
             _LOGGER.debug("Fetching all values to allow profiles to detect device")
             keys_to_read = api_client.register_map.base_keys
@@ -322,10 +333,11 @@ class AtwMbs02ConfigProvider:
             if result == ReadResult.GATEWAY_NOT_READY:
                 # _data is not populated; trying to decode would yield None
                 # values and crash. Surface a user-facing error instead.
-                return [], "gateway_not_ready"
+                return [], 0, "gateway_not_ready"
             all_data = {key: await api_client.read_value(key) for key in keys_to_read}
 
             decoded_data = api_client.decode_config(all_data)
+            system_config = int(all_data.get("system_config") or 0)
 
             _LOGGER.debug("Detecting profile with data: %s", decoded_data)
             detected_profiles = [
@@ -335,9 +347,9 @@ class AtwMbs02ConfigProvider:
             _LOGGER.debug("Detected profiles: %s", detected_profiles)
             if not detected_profiles:
                 _LOGGER.warning("No profile detected, showing all available profiles")
-            return detected_profiles, None
+            return detected_profiles, system_config, None
         except (ModbusException, ConnectionException, OSError):
-            return [], "cannot_connect"
+            return [], 0, "cannot_connect"
         finally:
             if api_client.connected:
                 await api_client.close()

--- a/custom_components/hitachi_yutaki/api/config_providers/hc_a_mb.py
+++ b/custom_components/hitachi_yutaki/api/config_providers/hc_a_mb.py
@@ -129,6 +129,7 @@ class HcAMbConfigProvider:
 
             # Decode raw config to get boolean flags for profile detection
             decoded_data = api_client.decode_config(all_data)
+            system_config = int(all_data.get("system_config") or 0)
 
             _LOGGER.debug("HC-A-MB detecting profile with data: %s", decoded_data)
             detected_profiles = [
@@ -141,15 +142,21 @@ class HcAMbConfigProvider:
                     "No profile detected for HC-A-MB, showing all available profiles"
                 )
 
+            # Persist system_config so COP services and device capabilities
+            # can be initialised on next setup before any refresh (#308).
+            config_data: dict[str, Any] = {
+                CONF_NAME: name,
+                CONF_MODBUS_HOST: host,
+                CONF_MODBUS_PORT: port,
+                CONF_MODBUS_DEVICE_ID: device_id,
+                CONF_SCAN_INTERVAL: scan_interval,
+                CONF_UNIT_ID: unit_id,
+            }
+            if system_config:
+                config_data["system_config"] = system_config
+
             return StepOutcome(
-                config_data={
-                    CONF_NAME: name,
-                    CONF_MODBUS_HOST: host,
-                    CONF_MODBUS_PORT: port,
-                    CONF_MODBUS_DEVICE_ID: device_id,
-                    CONF_SCAN_INTERVAL: scan_interval,
-                    CONF_UNIT_ID: unit_id,
-                },
+                config_data=config_data,
                 detected_profiles=detected_profiles,
             )
 

--- a/custom_components/hitachi_yutaki/coordinator.py
+++ b/custom_components/hitachi_yutaki/coordinator.py
@@ -69,6 +69,11 @@ class HitachiYutakiDataCoordinator(DataUpdateCoordinator):
         self.derived_metrics: DerivedMetricsAdapter | None = None
         self._normal_interval = timedelta(seconds=entry.data[CONF_SCAN_INTERVAL])
         self._gateway_not_ready_count: int = 0
+        # Seed from persisted value (0 = unknown / never refreshed) so callers
+        # of has_dhw/has_pool/has_circuit get sensible answers before the
+        # first successful refresh. The api_client cache is the live source,
+        # this attribute only mirrors what's been observed for diagnostics.
+        self.system_config: int = entry.data.get("system_config", 0)
 
         # Telemetry (injected by async_setup_entry — always set, noop when OFF)
         self.telemetry_collector: TelemetryCollector = None  # type: ignore[assignment]
@@ -86,6 +91,7 @@ class HitachiYutakiDataCoordinator(DataUpdateCoordinator):
         super().__init__(
             hass,
             _LOGGER,
+            config_entry=entry,
             name=DOMAIN,
             update_interval=self._normal_interval,
         )
@@ -149,6 +155,20 @@ class HitachiYutakiDataCoordinator(DataUpdateCoordinator):
                 data[key] = await self.api_client.read_value(key)
 
             self.system_config = data.get("system_config", 0)
+
+            # Persist system_config in entry.data so COP services and device
+            # capabilities can be initialised at next setup *before* any
+            # refresh — survives reloads that hit gateway_not_ready (#308).
+            # Only write when the value actually changed to avoid churn.
+            persisted = self.config_entry.data.get("system_config")
+            if self.system_config and persisted != self.system_config:
+                self.hass.config_entries.async_update_entry(
+                    self.config_entry,
+                    data={
+                        **self.config_entry.data,
+                        "system_config": self.system_config,
+                    },
+                )
 
             # Inject api_client state into data for derived metrics
             data["is_defrosting"] = self.api_client.is_defrosting

--- a/tests/api/config_providers/test_atw_mbs_02.py
+++ b/tests/api/config_providers/test_atw_mbs_02.py
@@ -105,7 +105,11 @@ class TestAtwMbs02GatewayNotReady:
         """_detect_profiles must surface gateway_not_ready, not crash."""
         client = _make_mock_client(ReadResult.GATEWAY_NOT_READY)
         with _patch_client_class(client):
-            detected, error = await AtwMbs02ConfigProvider._detect_profiles(
+            (
+                detected,
+                system_config,
+                error,
+            ) = await AtwMbs02ConfigProvider._detect_profiles(
                 hass=MagicMock(),
                 context={
                     "name": "test",
@@ -116,6 +120,7 @@ class TestAtwMbs02GatewayNotReady:
                 variant="gen2",
             )
         assert detected == []
+        assert system_config == 0
         assert error == "gateway_not_ready"
         client.read_value.assert_not_called()  # short-circuit before decode
 

--- a/tests/test_coordinator_capability_flags.py
+++ b/tests/test_coordinator_capability_flags.py
@@ -1,0 +1,137 @@
+"""Tests for persisting system_config (capability flags) into entry.data.
+
+See issue #308: COP services / device capabilities must be initialisable at
+setup time *before* any first refresh, so that a reload during the gateway's
+H-LINK init window does not drop cooling / DHW / pool COP services for the
+session.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.hitachi_yutaki.api.base import ReadResult
+from custom_components.hitachi_yutaki.coordinator import HitachiYutakiDataCoordinator
+from custom_components.hitachi_yutaki.telemetry import (
+    NoopTelemetryClient,
+    TelemetryCollector,
+    TelemetryLevel,
+)
+from homeassistant.const import CONF_SCAN_INTERVAL
+
+_BASE_KEYS = ["system_config", "system_state"]
+
+
+def _make_coordinator(initial_entry_data: dict, system_config_value: int):
+    """Build a coordinator wired with read_value returning system_config_value."""
+    hass = MagicMock()
+    hass.config_entries.async_update_entry = MagicMock()
+
+    # Close the one-time telemetry coroutine immediately so we don't get
+    # "coroutine was never awaited" warnings during the test.
+    def _close_coro(coro):
+        coro.close()
+
+    hass.async_create_task = MagicMock(side_effect=_close_coro)
+
+    api_client = MagicMock()
+    api_client.connected = True
+    api_client.read_values = AsyncMock(return_value=ReadResult.SUCCESS)
+    api_client.is_defrosting = False
+    api_client.is_compressor_running = False
+    api_client.register_map.base_keys = list(_BASE_KEYS)
+
+    async def _read_value(key: str):
+        if key == "system_config":
+            return system_config_value
+        return None
+
+    api_client.read_value = AsyncMock(side_effect=_read_value)
+
+    profile = MagicMock()
+    profile.extra_register_keys = []
+
+    entry = MagicMock()
+    entry.data = dict(initial_entry_data)
+    entry.data.setdefault(CONF_SCAN_INTERVAL, 5)
+
+    with patch("custom_components.hitachi_yutaki.coordinator.ir"):
+        coord = HitachiYutakiDataCoordinator(hass, entry, api_client, profile)
+
+    coord.telemetry_collector = TelemetryCollector(level=TelemetryLevel.OFF)
+    coord.telemetry_client = NoopTelemetryClient()
+    coord._telemetry_meta = {
+        "instance_hash": "test",
+        "profile": "test",
+        "gateway_type": "test",
+        "ha_version": "test",
+        "integration_version": "test",
+        "power_supply": "single",
+    }
+    return coord, hass, entry
+
+
+@pytest.mark.asyncio
+async def test_coordinator_persists_system_config_on_first_successful_refresh():
+    """First time we see a non-zero system_config, persist it in entry.data."""
+    coord, hass, entry = _make_coordinator({}, system_config_value=0x1234)
+
+    with patch("custom_components.hitachi_yutaki.coordinator.ir"):
+        await coord._async_update_data()
+
+    hass.config_entries.async_update_entry.assert_called_once()
+    args, kwargs = hass.config_entries.async_update_entry.call_args
+    assert kwargs["data"]["system_config"] == 0x1234
+
+
+@pytest.mark.asyncio
+async def test_coordinator_does_not_write_when_system_config_unchanged():
+    """No async_update_entry call when persisted value already matches live value."""
+    coord, hass, entry = _make_coordinator(
+        {"system_config": 0x1234}, system_config_value=0x1234
+    )
+
+    with patch("custom_components.hitachi_yutaki.coordinator.ir"):
+        await coord._async_update_data()
+
+    hass.config_entries.async_update_entry.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_coordinator_updates_persisted_value_when_changed():
+    """When the live system_config differs from persisted, persist the new value."""
+    coord, hass, entry = _make_coordinator(
+        {"system_config": 0x1234}, system_config_value=0x5678
+    )
+
+    with patch("custom_components.hitachi_yutaki.coordinator.ir"):
+        await coord._async_update_data()
+
+    hass.config_entries.async_update_entry.assert_called_once()
+    args, kwargs = hass.config_entries.async_update_entry.call_args
+    assert kwargs["data"]["system_config"] == 0x5678
+
+
+@pytest.mark.asyncio
+async def test_coordinator_does_not_persist_when_live_value_is_zero():
+    """Guard against persisting a meaningless 0 when read returns None / 0."""
+    coord, hass, entry = _make_coordinator({}, system_config_value=0)
+
+    with patch("custom_components.hitachi_yutaki.coordinator.ir"):
+        await coord._async_update_data()
+
+    hass.config_entries.async_update_entry.assert_not_called()
+
+
+def test_coordinator_seeds_system_config_from_entry_data():
+    """The coordinator exposes the persisted system_config before the first poll."""
+    coord, _, _ = _make_coordinator({"system_config": 0x42}, system_config_value=0x42)
+    assert coord.system_config == 0x42
+
+
+def test_coordinator_defaults_system_config_to_zero():
+    """Entries without persisted system_config (existing installs) default to 0."""
+    coord, _, _ = _make_coordinator({}, system_config_value=0)
+    assert coord.system_config == 0

--- a/tests/test_init_persisted_flags.py
+++ b/tests/test_init_persisted_flags.py
@@ -1,0 +1,132 @@
+"""Tests for capability-flag seeding at setup time from entry.data.
+
+See issue #308: when the first refresh fails with gateway_not_ready, COP
+services for cooling / DHW / pool must still be initialised based on the
+last-known system_config persisted in entry.data.
+"""
+
+from __future__ import annotations
+
+from custom_components.hitachi_yutaki.api.modbus import ModbusApiClient
+from custom_components.hitachi_yutaki.api.modbus.registers.atw_mbs_02 import (
+    AtwMbs02RegisterMap,
+)
+from custom_components.hitachi_yutaki.const import (
+    CIRCUIT_MODE_COOLING,
+    CIRCUIT_MODE_HEATING,
+    CIRCUIT_PRIMARY_ID,
+    CIRCUIT_SECONDARY_ID,
+)
+
+_ATW_REGISTERS = AtwMbs02RegisterMap()
+
+
+def _decode_flags(system_config: int) -> dict[str, bool]:
+    """Decode a system_config value via the real api_client.decode_config().
+
+    Mirrors what async_setup_entry does at #308 fix-time, so the result drives
+    DerivedMetricsAdapter(has_cooling=…, has_dhw=…, has_pool=…) deterministically.
+    """
+    # We don't need a real Modbus connection: decode_config is a pure decoder.
+    client = ModbusApiClient.__new__(ModbusApiClient)
+    client._register_map = _ATW_REGISTERS
+    decoded = client.decode_config({"system_config": system_config})
+    return {
+        "has_cooling": decoded["has_circuit1_cooling"]
+        or decoded["has_circuit2_cooling"],
+        "has_dhw": decoded["has_dhw"],
+        "has_pool": decoded["has_pool"],
+    }
+
+
+def _build_system_config(
+    *,
+    circuit1_heating: bool = False,
+    circuit1_cooling: bool = False,
+    circuit2_heating: bool = False,
+    circuit2_cooling: bool = False,
+    dhw: bool = False,
+    pool: bool = False,
+) -> int:
+    """Compose a system_config integer matching ATW-MBS-02 masks."""
+    value = 0
+    if circuit1_heating:
+        value |= _ATW_REGISTERS.masks_circuit[
+            (CIRCUIT_PRIMARY_ID, CIRCUIT_MODE_HEATING)
+        ]
+    if circuit1_cooling:
+        value |= _ATW_REGISTERS.masks_circuit[
+            (CIRCUIT_PRIMARY_ID, CIRCUIT_MODE_COOLING)
+        ]
+    if circuit2_heating:
+        value |= _ATW_REGISTERS.masks_circuit[
+            (CIRCUIT_SECONDARY_ID, CIRCUIT_MODE_HEATING)
+        ]
+    if circuit2_cooling:
+        value |= _ATW_REGISTERS.masks_circuit[
+            (CIRCUIT_SECONDARY_ID, CIRCUIT_MODE_COOLING)
+        ]
+    if dhw:
+        value |= _ATW_REGISTERS.mask_dhw
+    if pool:
+        value |= _ATW_REGISTERS.mask_pool
+    return value
+
+
+def test_persisted_zero_yields_all_false_flags():
+    """Migration path: entries without persisted system_config get all-False."""
+    flags = _decode_flags(0)
+    assert flags == {"has_cooling": False, "has_dhw": False, "has_pool": False}
+
+
+def test_persisted_heating_only_keeps_cooling_dhw_pool_off():
+    """Heating-only entry: only the heating COP service should be created."""
+    cfg = _build_system_config(circuit1_heating=True)
+    flags = _decode_flags(cfg)
+    assert flags == {"has_cooling": False, "has_dhw": False, "has_pool": False}
+
+
+def test_persisted_heating_plus_dhw_flags_dhw_on():
+    """Heating + DHW: cooling COP off, DHW COP on."""
+    cfg = _build_system_config(circuit1_heating=True, dhw=True)
+    flags = _decode_flags(cfg)
+    assert flags == {"has_cooling": False, "has_dhw": True, "has_pool": False}
+
+
+def test_persisted_heating_plus_cooling_flags_cooling_on():
+    """Reversible heat pump: cooling COP must be initialised at setup time."""
+    cfg = _build_system_config(circuit1_heating=True, circuit1_cooling=True)
+    flags = _decode_flags(cfg)
+    assert flags == {"has_cooling": True, "has_dhw": False, "has_pool": False}
+
+
+def test_persisted_with_pool_flags_pool_on():
+    """Pool COP service must be initialised when system_config has the pool bit."""
+    cfg = _build_system_config(circuit1_heating=True, pool=True)
+    flags = _decode_flags(cfg)
+    assert flags == {"has_cooling": False, "has_dhw": False, "has_pool": True}
+
+
+def test_persisted_two_circuits_with_cooling_on_circuit2():
+    """has_cooling must consider both circuits (OR semantics)."""
+    cfg = _build_system_config(
+        circuit1_heating=True,
+        circuit2_heating=True,
+        circuit2_cooling=True,
+    )
+    flags = _decode_flags(cfg)
+    assert flags["has_cooling"] is True
+
+
+def test_persisted_full_capability_unit():
+    """Full reversible unit with DHW and pool: all COP services initialised."""
+    cfg = _build_system_config(
+        circuit1_heating=True,
+        circuit1_cooling=True,
+        circuit2_heating=True,
+        circuit2_cooling=True,
+        dhw=True,
+        pool=True,
+    )
+    flags = _decode_flags(cfg)
+    assert flags == {"has_cooling": True, "has_dhw": True, "has_pool": True}


### PR DESCRIPTION
## Summary

Persist the gateway `system_config` bitfield (DHW / pool / circuit / cooling masks) in `entry.data` on every successful refresh, and read it back at `async_setup_entry` time to initialise COP services *before* the first refresh. This keeps cooling / DHW / pool COP services alive across a reload that hits `gateway_not_ready` during the gateway's H-LINK init window.

Closes #308.

## Root cause

Follow-up to #303 / PR #307. After #307 the integration tolerates `gateway_not_ready` on reload (entities go unavailable, recover on next poll). However, `_init_cop_services(...)` runs after the first refresh, reading `coordinator.has_dhw() / has_pool() / has_circuit(...)` from `system_config`. When the first refresh fails with `gateway_not_ready`, those flags are all `False`, so the COP services for cooling / DHW / pool are not created for the session — they only come back on the next successful reload.

## Fix

1. **`coordinator._async_update_data`**: after reading `system_config`, persist it into `entry.data` via `hass.config_entries.async_update_entry(...)` when it changed (no-op when unchanged or when the value is `0`, to avoid storing meaningless reads). Passes `config_entry=entry` to `DataUpdateCoordinator.__init__` so HA core wires `self.config_entry` properly.
2. **`__init__.async_setup_entry`**: decode `entry.data["system_config"]` via `api_client.decode_config(...)` and pass `has_cooling / has_dhw / has_pool` to `DerivedMetricsAdapter` *before* the first refresh. After the first refresh, if the live value disagrees with the persisted one (first-time setup, or capability changed on the unit), re-init COP services with the live flags.
3. **Config providers** (`atw_mbs_02`, `hc_a_mb`): include `system_config` in `StepOutcome.config_data`. `_detect_profiles` now returns `(detected_profiles, system_config, error_key)`. The value flows through `_step_context` into the entry data on creation and through the options flow on reconfigure.

## Migration

Implicit fallback: existing entries don't have `system_config` persisted. On setup, the persisted-flag path returns all-`False`; the integration falls back to the existing post-refresh re-init. On the first successful refresh, the value gets persisted; from then on every reload (including ones that hit `gateway_not_ready`) has the correct flags. No schema bump, no `async_migrate_entry` changes — the very first reload after upgrade still has the original problem, then it's self-healing on subsequent reloads. Acceptable per the issue's acceptance criteria.

## Dependencies

This builds on the same setup path that PR #307 touches. They don't conflict structurally but if #307 lands first there will be a trivial diff overlap to rebase. Flagging here so the merge order is explicit.

## Test plan

- [x] `tests/test_coordinator_capability_flags.py` — unit tests for the persistence write path: first non-zero refresh writes; unchanged value does not write; changed value writes; zero never writes; persisted value seeds `coordinator.system_config` at construction.
- [x] `tests/test_init_persisted_flags.py` — unit tests for the decode-from-entry-data path covering all capability combinations (heating-only, +DHW, +cooling on either circuit, +pool, full reversible unit).
- [x] `tests/api/config_providers/test_atw_mbs_02.py` updated for the new `_detect_profiles` 3-tuple return.
- [x] `make check` clean (ruff lint + format).
- [x] `make test` green (343 tests pass).
- [ ] Manual: reload an entry during the H-LINK init window after a successful run; verify cooling / DHW / pool COP sensors remain present (`sensor.<name>_cop_*`).
- [ ] Manual: fresh config flow against a unit with DHW + cooling; verify `entry.data["system_config"]` is populated immediately, no need to wait for the first poll.