### PR TITLE
fix(cop): correct electrical power with whole-unit power meter (#316)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Telemetry backend: `backend/grafana/koppen-zones.geojson`, a simplified Köppen-Geiger climate-zone polygon set (29 classes, polar `EF`/`ET` excluded, keyed by `CODE`/`name`) for a climate-zone choropleth panel on the fleet-inventory Grafana dashboard. Active zones are painted with their canonical Köppen family colours (the install count shows in the tooltip and as a per-zone label); zones with no installs stay a neutral, theme-aware grey. Provenance and the `mapshaper` regeneration command are documented in the dashboard design doc.
 
+### Fixed
+- COP: fix electrical power double-counting on S80 units when a whole-unit power meter (`power_entity`) is configured. The derived-metrics calculator was called once per compressor and the results summed; with a power meter each call returns the *total* unit power, so the sum was ~2x the real consumption and COP was roughly halved. Electrical power is now computed with a single calculator call using the summed compressor current, which is correct for both the measured-power path (whole unit returned once) and the I×U estimate (`U×(I1+I2) == U×I1 + U×I2`) (#316).
+- COP: fix incorrect COP reconstruction on restart for installations using a whole-unit power meter. During Recorder rehydration every replayed point was stamped with a single live `power_entity` reading captured at startup, instead of each point's own historical value. Rehydration now fetches the historical `power_entity` (and `voltage_entity`) from the Recorder and reconstructs the electrical power per point at its own timestamp (falling back to the per-point I×U estimate when no power meter is configured), matching how historical water temperatures are already replayed (#316).
+
 ## [2.1.3] - 2026-05-29
 
 ### Fixed

--- a/custom_components/hitachi_yutaki/adapters/derived_metrics.py
+++ b/custom_components/hitachi_yutaki/adapters/derived_metrics.py
@@ -27,6 +27,8 @@ from ..adapters.providers.operation_mode import (
 from ..adapters.storage.in_memory import InMemoryStorage
 from ..const import (
     CONF_ELECTRICITY_PRICE_ENTITY,
+    CONF_POWER_ENTITY,
+    CONF_VOLTAGE_ENTITY,
     CONF_WATER_INLET_TEMP_ENTITY,
     CONF_WATER_OUTLET_TEMP_ENTITY,
     DEFAULT_SCAN_INTERVAL,
@@ -70,6 +72,7 @@ class DerivedMetricsAdapter:
         )
         self._has_cooling = has_cooling
         self._supports_secondary_compressor = supports_secondary_compressor
+        self._is_three_phase = power_supply == "three"
 
         # Defrost guard (shared across all derived metrics)
         self.defrost_guard = DefrostGuard()
@@ -256,19 +259,29 @@ class DerivedMetricsAdapter:
 
     def _update_cop(self, data: dict[str, Any]) -> None:
         """Compute electrical power and COP for all configured modes."""
-        # Electrical power — sum primary + secondary compressor
+        # Electrical power — call the calculator ONCE with the summed current.
+        #
+        # Issue #316: calling the calculator twice (once per compressor) and
+        # summing double-counts when a whole-unit power meter (CONF_POWER_ENTITY)
+        # is configured, because the calculator returns the *total* measured
+        # power for both calls (~2x real -> COP halved on S80 + power meter).
+        #
+        # Summing the currents first is correct for both backends:
+        #   - measured_power path: returned once (whole unit) -> no double count.
+        #   - I×U estimate path: U×(I1+I2) == U×I1 + U×I2 -> identical to old sum.
         electrical_power = 0.0
         current = data.get("compressor_current")
-        if current is not None and current > 0:
-            electrical_power = self._electrical_calculator(current)
+        total_current = current if current is not None and current > 0 else 0.0
 
         if self._supports_secondary_compressor:
             sec_current = data.get("secondary_compressor_current")
             sec_freq = data.get("secondary_compressor_frequency")
+            # Only count the secondary compressor when it is actually running.
             if sec_current is not None and sec_freq is not None and sec_freq > 0:
-                sec_power = self._electrical_calculator(sec_current)
-                if sec_power > 0:
-                    electrical_power += sec_power
+                total_current += sec_current
+
+        if total_current > 0:
+            electrical_power = self._electrical_calculator(total_current)
 
         data["electrical_power"] = round(electrical_power, 3)
         _LOGGER.debug(
@@ -449,6 +462,15 @@ class DerivedMetricsAdapter:
                 if eid:
                     entity_map[key] = eid
 
+        # Optional external power/voltage meters (#316): include their *historical*
+        # values so each replayed point uses its own power, not a single live read.
+        power_entity = self._config_entry_data.get(CONF_POWER_ENTITY)
+        if power_entity:
+            entity_map["power_entity"] = power_entity
+        voltage_entity = self._config_entry_data.get(CONF_VOLTAGE_ENTITY)
+        if voltage_entity:
+            entity_map["voltage_entity"] = voltage_entity
+
         # Rehydrate each COP service
         for cop_key, service in self._cop_services.items():
             accepted_states: set[str] | None = None
@@ -460,11 +482,11 @@ class DerivedMetricsAdapter:
                     hass=self._hass,
                     entity_ids=entity_map,
                     thermal_calculator=thermal_power_calculator_wrapper,
-                    electrical_calculator=self._electrical_calculator,
                     window=COP_MEASUREMENTS_PERIOD,
                     measurement_interval=COP_MEASUREMENTS_INTERVAL,
                     max_measurements=COP_MEASUREMENTS_HISTORY_SIZE,
                     accepted_operation_states=accepted_states,
+                    is_three_phase=self._is_three_phase,
                 )
                 if measurements:
                     service.preload_measurements(measurements)

--- a/custom_components/hitachi_yutaki/adapters/storage/recorder_rehydrate.py
+++ b/custom_components/hitachi_yutaki/adapters/storage/recorder_rehydrate.py
@@ -7,10 +7,14 @@ from datetime import datetime, timedelta
 import logging
 
 from homeassistant.components.recorder import get_instance, history
+from homeassistant.const import UnitOfPower
 from homeassistant.core import HomeAssistant, State
 from homeassistant.util import dt as dt_util
+from homeassistant.util.unit_conversion import PowerConverter
 
 from ...domain.models.cop import PowerMeasurement
+from ...domain.models.electrical import ElectricalPowerInput
+from ...domain.services.electrical import calculate_electrical_power
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,13 +27,30 @@ async def async_replay_cop_history(
     *,
     entity_ids: dict[str, str],
     thermal_calculator: ThermalCalculator,
-    electrical_calculator: ElectricalCalculator,
+    electrical_calculator: ElectricalCalculator | None = None,
     window: timedelta,
     measurement_interval: int,
     max_measurements: int,
     accepted_operation_states: set[str] | None = None,
+    is_three_phase: bool = False,
 ) -> list[PowerMeasurement]:
-    """Reconstruct power measurements from Recorder sensor history."""
+    """Reconstruct power measurements from Recorder sensor history.
+
+    Electrical power is rebuilt per replayed point from that point's *historical*
+    data (issue #316): when a whole-unit power meter is configured its value is
+    looked up under the ``power_entity`` / ``measured_power`` key for the matching
+    timestamp; otherwise an I×U estimate is computed from the historical current
+    (and historical voltage when available). The live ``electrical_calculator`` is
+    intentionally NOT used here — reusing it would stamp the single instantaneous
+    live power reading onto every replayed point.
+
+    ``electrical_calculator`` is accepted for backward compatibility but ignored.
+    """
+    if electrical_calculator is not None:
+        _LOGGER.debug(
+            "async_replay_cop_history ignores the live electrical_calculator; "
+            "electrical power is reconstructed per-point from history (#316)"
+        )
     required_keys = {
         "water_inlet_temp",
         "water_outlet_temp",
@@ -63,6 +84,32 @@ async def async_replay_cop_history(
                 for state in states
                 if state.state not in (None, "unknown", "unavailable")
             )
+        elif key == "power_entity":
+            # Whole-unit power meter: normalise each historical reading to kW
+            # using its own unit_of_measurement and store under "measured_power".
+            for state in states:
+                parsed = _parse_power_kw(state)
+                if parsed is None:
+                    continue
+                timeline.append(
+                    (
+                        _as_local_naive(state.last_changed or state.last_updated),
+                        "measured_power",
+                        parsed,
+                    )
+                )
+        elif key == "voltage_entity":
+            for state in states:
+                parsed = _parse_float(state)
+                if parsed is None:
+                    continue
+                timeline.append(
+                    (
+                        _as_local_naive(state.last_changed or state.last_updated),
+                        "voltage",
+                        parsed,
+                    )
+                )
         else:
             parser = _parse_bool if key.endswith("_running") else _parse_float
             for state in states:
@@ -106,7 +153,7 @@ async def async_replay_cop_history(
             timestamp,
             latest,
             thermal_calculator,
-            electrical_calculator,
+            is_three_phase=is_three_phase,
         )
         if measurement is None:
             continue
@@ -151,8 +198,16 @@ def _build_power_measurement(
     timestamp: datetime,
     latest: dict[str, float],
     thermal_calculator: ThermalCalculator,
-    electrical_calculator: ElectricalCalculator,
+    *,
+    is_three_phase: bool = False,
 ) -> PowerMeasurement | None:
+    """Build a single COP measurement from the per-point historical snapshot.
+
+    Electrical power is reconstructed from this point's own historical values
+    (issue #316): a whole-unit power meter reading wins (``measured_power``,
+    already in kW); otherwise an I×U estimate is computed from the summed
+    historical compressor currents and the historical (or default) voltage.
+    """
     try:
         water_inlet = latest["water_inlet_temp"]
         water_outlet = latest["water_outlet_temp"]
@@ -165,17 +220,26 @@ def _build_power_measurement(
     if thermal_power <= 0:
         return None
 
-    electrical_power = electrical_calculator(compressor_current)
-    if electrical_power <= 0:
-        return None
+    measured_power = latest.get("measured_power")
+    voltage = latest.get("voltage")
 
+    # Sum compressor currents (S80) so a single calculation covers the whole
+    # unit. For the measured_power path the current is ignored anyway; for the
+    # I×U path U×(I1+I2) == U×I1 + U×I2.
+    total_current = compressor_current
     secondary_frequency = latest.get("secondary_compressor_frequency")
     secondary_current = latest.get("secondary_compressor_current")
     if secondary_frequency and secondary_frequency > 0 and secondary_current:
-        additional = electrical_calculator(secondary_current)
-        if additional > 0:
-            electrical_power += additional
+        total_current += secondary_current
 
+    electrical_power = calculate_electrical_power(
+        ElectricalPowerInput(
+            current=total_current,
+            measured_power=measured_power,
+            voltage=voltage,
+            is_three_phase=is_three_phase,
+        )
+    )
     if electrical_power <= 0:
         return None
 
@@ -186,6 +250,20 @@ def _parse_float(state: State) -> float | None:
     try:
         return float(state.state)
     except (TypeError, ValueError):
+        return None
+
+
+def _parse_power_kw(state: State) -> float | None:
+    """Parse a power-meter state and normalise it to kW via its unit attribute."""
+    value = _parse_float(state)
+    if value is None:
+        return None
+    from_unit = state.attributes.get("unit_of_measurement")
+    if from_unit is None:
+        return None
+    try:
+        return PowerConverter.convert(value, from_unit, UnitOfPower.KILO_WATT)
+    except (ValueError, KeyError):
         return None
 
 

--- a/custom_components/hitachi_yutaki/domain/services/cop.py
+++ b/custom_components/hitachi_yutaki/domain/services/cop.py
@@ -225,23 +225,22 @@ class COPService:
             data.water_flow,  # type: ignore
         )
 
-        # Use pre-computed electrical power if available, else compute from current
+        # Use pre-computed electrical power if available, else compute from current.
+        #
+        # Fallback path: call the calculator ONCE with the summed compressor
+        # current. Calling it per compressor and summing would double-count when
+        # the calculator returns a whole-unit measured power (issue #316).
         if data.electrical_power is not None:
             electrical_power = data.electrical_power
         else:
-            electrical_power = self._electrical_calculator(
-                data.compressor_current  # type: ignore
-            )
+            total_current = data.compressor_current  # type: ignore
             if (
                 data.secondary_compressor_current is not None
                 and data.secondary_compressor_frequency is not None
                 and data.secondary_compressor_frequency > 0
             ):
-                additional_power = self._electrical_calculator(
-                    data.secondary_compressor_current
-                )
-                if additional_power > 0:
-                    electrical_power += additional_power
+                total_current += data.secondary_compressor_current
+            electrical_power = self._electrical_calculator(total_current)
 
         # Store measurement if valid
         if thermal_power > 0 and electrical_power > 0:

--- a/tests/adapters/test_derived_metrics.py
+++ b/tests/adapters/test_derived_metrics.py
@@ -5,6 +5,10 @@ from unittest.mock import MagicMock
 from custom_components.hitachi_yutaki.adapters.derived_metrics import (
     DerivedMetricsAdapter,
 )
+from custom_components.hitachi_yutaki.domain.services.electrical import (
+    POWER_FACTOR,
+    VOLTAGE_SINGLE_PHASE,
+)
 
 
 def _sample_data(**overrides) -> dict:
@@ -451,3 +455,58 @@ class TestEnergyAndCost:
         assert data["electrical_power"] > 0
         # COP keys should be present (uses the same electrical_power)
         assert "cop_heating" in data
+
+    def test_s80_with_power_meter_does_not_double_count(self):
+        """Regression #316: S80 + whole-unit power meter must not double-count.
+
+        With ``power_entity`` configured, the meter reports total unit power.
+        Summing two per-compressor calculator calls (both returning the same
+        whole-unit value) yields ~2x the real power, halving COP.
+        """
+        mock_hass = MagicMock()
+
+        power_state = MagicMock()
+        power_state.state = "3000"  # 3000 W = 3 kW whole unit
+        power_state.attributes = {"unit_of_measurement": "W"}
+
+        config_entry = MagicMock()
+        config_entry.data = {"power_entity": "sensor.unit_power"}
+
+        def states_get(entity_id):
+            if entity_id == "sensor.unit_power":
+                return power_state
+            return None
+
+        mock_hass.states.get = states_get
+
+        adapter = DerivedMetricsAdapter(
+            hass=mock_hass,
+            config_entry=config_entry,
+            power_supply="single",
+            supports_secondary_compressor=True,
+        )
+
+        data = _sample_data(
+            compressor_current=8.5,
+            secondary_compressor_current=6.0,
+            secondary_compressor_frequency=50.0,
+        )
+        adapter.update(data)
+        # measured whole-unit power is 3 kW; must NOT be ~6 kW
+        assert data["electrical_power"] == 3.0
+
+    def test_s80_ixu_estimate_matches_summed_current(self):
+        """S80 I×U estimate is unchanged: U×(I1+I2) == U×I1 + U×I2.
+
+        Guards the refactor that calls the calculator once with the summed
+        current instead of twice.
+        """
+        adapter = _make_adapter(supports_secondary_compressor=True)
+        data = _sample_data(
+            compressor_current=8.5,
+            secondary_compressor_current=6.0,
+            secondary_compressor_frequency=50.0,
+        )
+        adapter.update(data)
+        expected = round((VOLTAGE_SINGLE_PHASE * (8.5 + 6.0) * POWER_FACTOR) / 1000, 3)
+        assert data["electrical_power"] == expected

--- a/tests/adapters/test_recorder_rehydrate.py
+++ b/tests/adapters/test_recorder_rehydrate.py
@@ -1,0 +1,140 @@
+"""Tests for COP rehydration from Recorder history (issue #316).
+
+Regression coverage: during rehydration the electrical power of each replayed
+point must be reconstructed from that point's *historical* data, never from a
+single live ``power_entity`` reading captured at rehydration time.
+"""
+
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.hitachi_yutaki.adapters.storage import recorder_rehydrate
+from custom_components.hitachi_yutaki.adapters.storage.recorder_rehydrate import (
+    async_replay_cop_history,
+)
+from custom_components.hitachi_yutaki.domain.services.electrical import (
+    POWER_FACTOR,
+    VOLTAGE_SINGLE_PHASE,
+)
+from homeassistant.util import dt as dt_util
+
+
+def _state(value, when, *, unit=None):
+    """Build a fake HA State-like object."""
+    st = MagicMock()
+    st.state = str(value)
+    st.last_changed = when
+    st.last_updated = when
+    st.attributes = {"unit_of_measurement": unit} if unit else {}
+    return st
+
+
+def _thermal_calc(inlet, outlet, flow):
+    """Return a positive thermal power so measurements are kept."""
+    return max(outlet - inlet, 0.0) * flow * 0.001 + 1.0
+
+
+@pytest.mark.asyncio
+async def test_rehydration_uses_per_point_historical_power():
+    """Each replayed point gets power from its own historical power_entity value.
+
+    Two timestamps with different whole-unit power meter readings must produce
+    two PowerMeasurements with *different* electrical_power, not the same live
+    value stamped on both.
+    """
+    now = dt_util.utcnow()
+    t0 = now - timedelta(minutes=20)
+    t1 = now - timedelta(minutes=5)
+
+    entity_ids = {
+        "water_inlet_temp": "sensor.inlet",
+        "water_outlet_temp": "sensor.outlet",
+        "water_flow": "sensor.flow",
+        "compressor_current": "sensor.current",
+        "compressor_frequency": "sensor.freq",
+        "power_entity": "sensor.unit_power",
+    }
+
+    states_map = {
+        "sensor.inlet": [_state(30.0, t0), _state(30.0, t1)],
+        "sensor.outlet": [_state(35.0, t0), _state(35.0, t1)],
+        "sensor.flow": [_state(12.0, t0), _state(12.0, t1)],
+        "sensor.current": [_state(8.0, t0), _state(8.0, t1)],
+        "sensor.freq": [_state(60.0, t0), _state(60.0, t1)],
+        # whole-unit power meter: 2 kW at t0, 4 kW at t1
+        "sensor.unit_power": [
+            _state(2000, t0, unit="W"),
+            _state(4000, t1, unit="W"),
+        ],
+    }
+
+    async def _fake_fetch(hass, ids, window, *, include_start_state):
+        return {eid: states_map.get(eid, []) for eid in ids}
+
+    hass = MagicMock()
+
+    with patch.object(recorder_rehydrate, "_async_fetch_history", _fake_fetch):
+        measurements = await async_replay_cop_history(
+            hass=hass,
+            entity_ids=entity_ids,
+            thermal_calculator=_thermal_calc,
+            electrical_calculator=lambda current: 999.0,  # live value, must NOT be used
+            window=timedelta(minutes=30),
+            measurement_interval=0,
+            max_measurements=100,
+        )
+
+    powers = {m.electrical_power for m in measurements}
+    # Both per-point historical readings appear: 2 kW (t0) and 4 kW (t1),
+    # converted from W. The 4 kW value proves later points are NOT stamped
+    # with the earlier reading.
+    assert 2.0 in powers
+    assert 4.0 in powers
+    # The live calculator value (999) must never appear.
+    assert 999.0 not in powers
+
+
+@pytest.mark.asyncio
+async def test_rehydration_falls_back_to_ixu_without_power_entity():
+    """Without power_entity, per-point I×U estimate is used per timestamp."""
+    now = dt_util.utcnow()
+    t0 = now - timedelta(minutes=10)
+
+    entity_ids = {
+        "water_inlet_temp": "sensor.inlet",
+        "water_outlet_temp": "sensor.outlet",
+        "water_flow": "sensor.flow",
+        "compressor_current": "sensor.current",
+        "compressor_frequency": "sensor.freq",
+    }
+
+    states_map = {
+        "sensor.inlet": [_state(30.0, t0)],
+        "sensor.outlet": [_state(35.0, t0)],
+        "sensor.flow": [_state(12.0, t0)],
+        "sensor.current": [_state(10.0, t0)],
+        "sensor.freq": [_state(60.0, t0)],
+    }
+
+    async def _fake_fetch(hass, ids, window, *, include_start_state):
+        return {eid: states_map.get(eid, []) for eid in ids}
+
+    hass = MagicMock()
+
+    with patch.object(recorder_rehydrate, "_async_fetch_history", _fake_fetch):
+        measurements = await async_replay_cop_history(
+            hass=hass,
+            entity_ids=entity_ids,
+            thermal_calculator=_thermal_calc,
+            electrical_calculator=lambda current: 999.0,
+            window=timedelta(minutes=30),
+            measurement_interval=0,
+            max_measurements=100,
+            is_three_phase=False,
+        )
+
+    expected = (VOLTAGE_SINGLE_PHASE * 10.0 * POWER_FACTOR) / 1000
+    assert len(measurements) == 1
+    assert measurements[0].electrical_power == pytest.approx(expected)


### PR DESCRIPTION
Fixes #316.

## Problem

`domain/services/electrical.py` short-circuits on `measured_power` and discards the per-call `current`. The adapter reads the **live** `power_entity` from `hass.states`. This caused two distinct correctness defects whenever a `power_entity` (whole-unit power meter) is configured:

- **S80 double-count:** `_update_cop` called the electrical calculator twice (primary + secondary current) and summed → the whole-unit `measured_power` was counted twice → COP roughly halved on S80 + power meter.
- **Rehydration:** during Recorder replay every historical point was stamped with the single instantaneous live power reading captured at restart → reconstructed COP wrong.

## Fix

- **S80 double-count:** `_update_cop` now sums primary + running-secondary compressor current and calls the calculator **once**. Correct for both backends — `measured_power` is returned once (whole unit), and the I×U estimate is unchanged since `U·(I1+I2) == U·I1 + U·I2`. The same latent bug was fixed in the `cop.py` `update()` fallback branch.
- **Rehydration (approach a):** `power_entity`/`voltage_entity` are added to the rehydration historical entity map; `async_replay_cop_history` parses their Recorder history per timestamp (W→kW via `PowerConverter`), and `_build_power_measurement` reconstructs electrical power per point via the pure domain `calculate_electrical_power` using that point's own historical values, with per-point I×U fallback when no meter is configured. Mirrors how historical water temps are already replayed.

## Tests

- New: S80-with-power-meter no-double-count, I×U-equals-summed-current invariant, per-point historical power on rehydration (live reading never reused). All confirmed red against pre-fix code.
- `uv run pytest tests/` → **355 passed**. `ruff check` clean.

## Review

Reviewed by an independent fresh agent (adversarial): math equivalence verified for single/three-phase, per-point historical power flow verified, no regression on the common no-meter single-compressor path, domain layer stays HA-agnostic.

_Found during a systematic multi-agent code audit._
