### PR TITLE
fix(init): use persisted capabilities when first refresh tolerates gateway_not_ready (#317)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-- ATW-MBS-02 (Before Line-up 2016): the "Room Thermostat available" flag is a single global register (address 1029), not a per-circuit control as on the 2016 line-up. The pre-2016 map previously defined `circuit2_thermostat` at the same address 1029 as `circuit1_thermostat`, so toggling circuit 2 silently rewrote the global flag (and shadowed circuit 1). The duplicate `circuit2_thermostat` key has been removed; the flag is now modelled once as `circuit1_thermostat` (#318).
-
 ### Added
 - Telemetry backend: `backend/grafana/koppen-zones.geojson`, a simplified Köppen-Geiger climate-zone polygon set (29 classes, polar `EF`/`ET` excluded, keyed by `CODE`/`name`) for a climate-zone choropleth panel on the fleet-inventory Grafana dashboard. Active zones are painted with their canonical Köppen family colours (the install count shows in the tooltip and as a per-zone label); zones with no installs stay a neutral, theme-aware grey. Provenance and the `mapshaper` regeneration command are documented in the dashboard design doc.
 
 ### Fixed
+- ATW-MBS-02 (Before Line-up 2016): the "Room Thermostat available" flag is a single global register (address 1029), not a per-circuit control as on the 2016 line-up. The pre-2016 map previously defined `circuit2_thermostat` at the same address 1029 as `circuit1_thermostat`, so toggling circuit 2 silently rewrote the global flag (and shadowed circuit 1). The duplicate `circuit2_thermostat` key has been removed; the flag is now modelled once as `circuit1_thermostat` (#318).
 - COP: fix electrical power double-counting on S80 units when a whole-unit power meter (`power_entity`) is configured. The derived-metrics calculator was called once per compressor and the results summed; with a power meter each call returns the *total* unit power, so the sum was ~2x the real consumption and COP was roughly halved. Electrical power is now computed with a single calculator call using the summed compressor current, which is correct for both the measured-power path (whole unit returned once) and the I×U estimate (`U×(I1+I2) == U×I1 + U×I2`) (#316).
 - COP: fix incorrect COP reconstruction on restart for installations using a whole-unit power meter. During Recorder rehydration every replayed point was stamped with a single live `power_entity` reading captured at startup, instead of each point's own historical value. Rehydration now fetches the historical `power_entity` (and `voltage_entity`) from the Recorder and reconstructs the electrical power per point at its own timestamp (falling back to the per-point I×U estimate when no power meter is configured), matching how historical water temperatures are already replayed (#316).
+- Setup: when the first refresh is tolerated through `gateway_not_ready` (#303/#307), the gateway's live `system_config` is unavailable (register data is empty), so live capability flags all read `False`. Setup now keeps using the persisted `system_config` (#308) in that case instead of the empty live data. This fixes two regressions: (1) COP services seeded from the persisted capabilities are no longer destroyed by a spurious live-vs-persisted mismatch re-init, and (2) DHW, Pool and Circuit 1/2 devices are now registered from the persisted capabilities instead of silently disappearing until a later reload hits a successful poll. When the first refresh succeeds, live capabilities remain authoritative and behaviour is unchanged (#317).
 
 ## [2.1.3] - 2026-05-29
 

--- a/custom_components/hitachi_yutaki/__init__.py
+++ b/custom_components/hitachi_yutaki/__init__.py
@@ -100,6 +100,54 @@ async def _async_first_refresh_tolerating_gateway_not_ready(
     return True
 
 
+def _resolve_effective_capabilities(
+    *,
+    data_is_fresh: bool,
+    live: dict[str, bool],
+    persisted: dict[str, bool],
+) -> dict[str, bool]:
+    """Resolve the capability flags used to gate device registration (#317).
+
+    When the first refresh succeeds, ``api_client._data`` holds fresh register
+    data and the LIVE ``coordinator.has_*()`` flags are authoritative. When the
+    refresh was tolerated through ``gateway_not_ready`` (#303/#307), ``_data`` is
+    EMPTY so every live flag is ``False``; in that case fall back to the flags
+    decoded from the persisted ``system_config`` (#308) so DHW/Pool/Circuit
+    devices are still registered instead of silently disappearing until a later
+    reload hits a successful poll.
+
+    Both dicts use the keys ``circuit1``, ``circuit2``, ``cooling``, ``dhw`` and
+    ``pool``.
+    """
+    return live if data_is_fresh else persisted
+
+
+def _should_reinit_cop_services(
+    *,
+    data_is_fresh: bool,
+    live: dict[str, bool],
+    persisted: dict[str, bool],
+) -> bool:
+    """Decide whether COP services must be re-initialised from LIVE capabilities.
+
+    The COP services were already seeded from the persisted ``system_config``
+    (#308). We only re-init them when the first refresh produced fresh data
+    (``data_is_fresh``) AND the live capabilities disagree with the persisted
+    ones (first-time setup, or a capability changed on the unit).
+
+    When data is NOT fresh (gateway_not_ready tolerated), the live flags are all
+    ``False`` and re-initialising would DESTROY the just-seeded services (#317
+    symptom 1), so we never re-init in that case.
+    """
+    if not data_is_fresh:
+        return False
+    return (
+        live["cooling"] != persisted["cooling"]
+        or live["dhw"] != persisted["dhw"]
+        or live["pool"] != persisted["pool"]
+    )
+
+
 async def _async_restore_thermal_energy(
     hass: HomeAssistant,
     entry: HitachiYutakiConfigEntry,
@@ -326,11 +374,24 @@ async def async_setup_entry(
     persisted_flags = api_client.decode_config(
         {"system_config": entry.data.get("system_config", 0)}
     )
+    persisted_has_circuit1 = persisted_flags.get(
+        "has_circuit1_heating", False
+    ) or persisted_flags.get("has_circuit1_cooling", False)
+    persisted_has_circuit2 = persisted_flags.get(
+        "has_circuit2_heating", False
+    ) or persisted_flags.get("has_circuit2_cooling", False)
     persisted_has_cooling = persisted_flags.get(
         "has_circuit1_cooling", False
     ) or persisted_flags.get("has_circuit2_cooling", False)
     persisted_has_dhw = persisted_flags.get("has_dhw", False)
     persisted_has_pool = persisted_flags.get("has_pool", False)
+    persisted_caps = {
+        "circuit1": persisted_has_circuit1,
+        "circuit2": persisted_has_circuit2,
+        "cooling": persisted_has_cooling,
+        "dhw": persisted_has_dhw,
+        "pool": persisted_has_pool,
+    }
 
     # Create derived metrics adapter (enriches data with thermal power, COP, etc.)
     coordinator.derived_metrics = DerivedMetricsAdapter(
@@ -348,27 +409,49 @@ async def async_setup_entry(
     # entry: log a warning and continue. Entities will go ``available`` on the
     # next successful poll. Any other ConfigEntryNotReady is re-raised so HA
     # retries setup via its standard mechanism.
-    await _async_first_refresh_tolerating_gateway_not_ready(coordinator)
+    data_is_fresh = await _async_first_refresh_tolerating_gateway_not_ready(coordinator)
 
     _LOGGER.debug("Data coordinator initialized")
 
     entry.runtime_data = coordinator
 
-    # Re-initialise COP services if the live system_config disagrees with the
-    # persisted value (first-time setup, or capability changed on the unit).
-    live_has_cooling = coordinator.has_circuit(CIRCUIT_PRIMARY_ID, CIRCUIT_MODE_COOLING)
-    live_has_dhw = coordinator.has_dhw()
-    live_has_pool = coordinator.has_pool()
-    if (
-        live_has_cooling != persisted_has_cooling
-        or live_has_dhw != persisted_has_dhw
-        or live_has_pool != persisted_has_pool
+    # Live capabilities read straight from api_client._data. These are only
+    # meaningful when the first refresh produced fresh data; if it was tolerated
+    # through gateway_not_ready (#303/#307) the _data dict is empty and every
+    # flag below is False.
+    live_caps = {
+        "circuit1": coordinator.has_circuit(CIRCUIT_PRIMARY_ID, CIRCUIT_MODE_HEATING)
+        or coordinator.has_circuit(CIRCUIT_PRIMARY_ID, CIRCUIT_MODE_COOLING),
+        "circuit2": coordinator.has_circuit(CIRCUIT_SECONDARY_ID, CIRCUIT_MODE_HEATING)
+        or coordinator.has_circuit(CIRCUIT_SECONDARY_ID, CIRCUIT_MODE_COOLING),
+        "cooling": coordinator.has_circuit(CIRCUIT_PRIMARY_ID, CIRCUIT_MODE_COOLING)
+        or coordinator.has_circuit(CIRCUIT_SECONDARY_ID, CIRCUIT_MODE_COOLING),
+        "dhw": coordinator.has_dhw(),
+        "pool": coordinator.has_pool(),
+    }
+
+    # Effective capabilities used to gate device registration: live when fresh,
+    # persisted fallback when the first refresh was tolerated (#317 symptom 2).
+    effective_caps = _resolve_effective_capabilities(
+        data_is_fresh=data_is_fresh,
+        live=live_caps,
+        persisted=persisted_caps,
+    )
+
+    # Re-initialise COP services only when fresh data disagrees with the
+    # persisted value. When data is stale, the live flags are all False and
+    # re-initialising would destroy the COP services already seeded from the
+    # persisted system_config (#308, #317 symptom 1).
+    if _should_reinit_cop_services(
+        data_is_fresh=data_is_fresh,
+        live=live_caps,
+        persisted=persisted_caps,
     ):
-        coordinator.derived_metrics._has_cooling = live_has_cooling
+        coordinator.derived_metrics._has_cooling = live_caps["cooling"]
         coordinator.derived_metrics._init_cop_services(
-            has_cooling=live_has_cooling,
-            has_dhw=live_has_dhw,
-            has_pool=live_has_pool,
+            has_cooling=live_caps["cooling"],
+            has_dhw=live_caps["dhw"],
+            has_pool=live_caps["pool"],
         )
 
     # Restore thermal energy from last known state
@@ -436,9 +519,7 @@ async def async_setup_entry(
         )
 
     # Add Circuit 1 device if configured
-    if coordinator.has_circuit(
-        CIRCUIT_PRIMARY_ID, CIRCUIT_MODE_HEATING
-    ) or coordinator.has_circuit(CIRCUIT_PRIMARY_ID, CIRCUIT_MODE_COOLING):
+    if effective_caps["circuit1"]:
         _LOGGER.debug("Circuit 1 configured, registering device")
         device_registry.async_get_or_create(
             config_entry_id=entry.entry_id,
@@ -451,9 +532,7 @@ async def async_setup_entry(
         )
 
     # Add Circuit 2 device if configured
-    if coordinator.has_circuit(
-        CIRCUIT_SECONDARY_ID, CIRCUIT_MODE_HEATING
-    ) or coordinator.has_circuit(CIRCUIT_SECONDARY_ID, CIRCUIT_MODE_COOLING):
+    if effective_caps["circuit2"]:
         _LOGGER.debug("Circuit 2 configured, registering device")
         device_registry.async_get_or_create(
             config_entry_id=entry.entry_id,
@@ -466,7 +545,7 @@ async def async_setup_entry(
         )
 
     # Add DHW device if configured
-    if coordinator.has_dhw():
+    if effective_caps["dhw"]:
         _LOGGER.debug("DHW configured, registering device")
         device_registry.async_get_or_create(
             config_entry_id=entry.entry_id,
@@ -479,7 +558,7 @@ async def async_setup_entry(
         )
 
     # Add Pool device if configured
-    if coordinator.has_pool():
+    if effective_caps["pool"]:
         _LOGGER.debug("Pool configured, registering device")
         device_registry.async_get_or_create(
             config_entry_id=entry.entry_id,

--- a/tests/test_init_gateway_not_ready_capabilities.py
+++ b/tests/test_init_gateway_not_ready_capabilities.py
@@ -1,0 +1,272 @@
+"""Tests for capability resolution when first refresh is tolerated (#317).
+
+Issue #317 (two linked HIGH-severity symptoms) -- when the first refresh is
+tolerated through ``gateway_not_ready`` (#303/#307), ``api_client._data`` is
+left EMPTY, so the LIVE ``coordinator.has_*()`` capabilities all return False.
+
+Symptom 1: COP services seeded from the persisted ``system_config`` (#308) get
+destroyed by the live-vs-persisted mismatch re-init.
+
+Symptom 2: DHW/Pool/Circuit devices, gated on the LIVE ``has_*()``, are not
+registered during setup.
+
+These tests exercise ``_resolve_effective_capabilities`` -- the pure helper that
+chooses LIVE flags when data is fresh and falls back to the persisted flags
+when it is not -- and the mismatch-reinit guard ``_should_reinit_cop_services``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.hitachi_yutaki import (
+    _resolve_effective_capabilities,
+    _should_reinit_cop_services,
+    async_setup_entry,
+)
+from custom_components.hitachi_yutaki.api.modbus.registers.atw_mbs_02 import (
+    AtwMbs02RegisterMap,
+)
+from custom_components.hitachi_yutaki.const import (
+    CIRCUIT_MODE_COOLING,
+    CIRCUIT_MODE_HEATING,
+    CIRCUIT_PRIMARY_ID,
+    CIRCUIT_SECONDARY_ID,
+    CONF_MODBUS_DEVICE_ID,
+    CONF_MODBUS_HOST,
+    CONF_MODBUS_PORT,
+    CONF_TELEMETRY_LEVEL,
+    DEFAULT_DEVICE_ID,
+    DEFAULT_HOST,
+    DEFAULT_NAME,
+    DEFAULT_PORT,
+    DEFAULT_POWER_SUPPLY,
+    DEFAULT_SCAN_INTERVAL,
+    DEVICE_CIRCUIT_2,
+    DEVICE_DHW,
+    DEVICE_POOL,
+    DOMAIN,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+_ATW_REGISTERS = AtwMbs02RegisterMap()
+
+
+def _caps(
+    *,
+    circuit1: bool = False,
+    circuit2: bool = False,
+    cooling: bool = False,
+    dhw: bool = False,
+    pool: bool = False,
+) -> dict[str, bool]:
+    return {
+        "circuit1": circuit1,
+        "circuit2": circuit2,
+        "cooling": cooling,
+        "dhw": dhw,
+        "pool": pool,
+    }
+
+
+# --- Symptom 2: device-gating capabilities -------------------------------
+
+
+def test_fresh_data_uses_live_capabilities():
+    """When data is fresh, LIVE capabilities are authoritative."""
+    live = _caps(circuit1=True, dhw=True)
+    persisted = _caps(circuit1=True, circuit2=True, cooling=True, dhw=True, pool=True)
+
+    effective = _resolve_effective_capabilities(
+        data_is_fresh=True, live=live, persisted=persisted
+    )
+
+    # Live wins entirely, persisted is ignored.
+    assert effective == live
+
+
+def test_stale_data_falls_back_to_persisted_capabilities():
+    """Stale data: persisted flags drive device gating (#317 symptom 2)."""
+    # Empty _data -> every live flag is False.
+    live = _caps()
+    persisted = _caps(circuit1=True, circuit2=True, cooling=True, dhw=True, pool=True)
+
+    effective = _resolve_effective_capabilities(
+        data_is_fresh=False, live=live, persisted=persisted
+    )
+
+    assert effective == persisted
+    # The whole point: DHW / Pool / Circuit2 devices would be registered.
+    assert effective["dhw"] is True
+    assert effective["pool"] is True
+    assert effective["circuit2"] is True
+    assert effective["circuit1"] is True
+
+
+def test_stale_data_heating_only_does_not_invent_capabilities():
+    """Stale fallback must not over-register: heating-only stays heating-only."""
+    live = _caps()
+    persisted = _caps(circuit1=True)
+
+    effective = _resolve_effective_capabilities(
+        data_is_fresh=False, live=live, persisted=persisted
+    )
+
+    assert effective["circuit1"] is True
+    assert effective["circuit2"] is False
+    assert effective["cooling"] is False
+    assert effective["dhw"] is False
+    assert effective["pool"] is False
+
+
+# --- Symptom 1: COP-service mismatch re-init guard -----------------------
+
+
+def test_no_reinit_when_data_is_stale():
+    """Stale data: never re-init COP services -> persisted #308 seeding survives."""
+    # Live all-False, persisted full capability -> a naive mismatch check would
+    # fire and DESTROY the COP services. The guard must prevent that.
+    live = _caps()
+    persisted = _caps(cooling=True, dhw=True, pool=True)
+
+    assert (
+        _should_reinit_cop_services(data_is_fresh=False, live=live, persisted=persisted)
+        is False
+    )
+
+
+def test_reinit_when_fresh_and_live_disagrees_with_persisted():
+    """Fresh data disagreeing with persisted must re-init (preserve old behaviour)."""
+    live = _caps(cooling=True, dhw=True, pool=False)
+    persisted = _caps(cooling=False, dhw=False, pool=False)
+
+    assert (
+        _should_reinit_cop_services(data_is_fresh=True, live=live, persisted=persisted)
+        is True
+    )
+
+
+def test_no_reinit_when_fresh_and_live_matches_persisted():
+    """Fresh data matching persisted needs no re-init (avoid redundant work)."""
+    live = _caps(cooling=True, dhw=True, pool=True)
+    persisted = _caps(cooling=True, dhw=True, pool=True)
+
+    assert (
+        _should_reinit_cop_services(data_is_fresh=True, live=live, persisted=persisted)
+        is False
+    )
+
+
+# --- Integration: full async_setup_entry wiring (#317) -------------------
+
+
+def _full_capability_system_config() -> int:
+    """Compose an ATW-MBS-02 system_config with dhw + pool + circuit2 + cooling."""
+    masks = _ATW_REGISTERS.masks_circuit
+    return (
+        masks[(CIRCUIT_PRIMARY_ID, CIRCUIT_MODE_HEATING)]
+        | masks[(CIRCUIT_PRIMARY_ID, CIRCUIT_MODE_COOLING)]
+        | masks[(CIRCUIT_SECONDARY_ID, CIRCUIT_MODE_HEATING)]
+        | masks[(CIRCUIT_SECONDARY_ID, CIRCUIT_MODE_COOLING)]
+        | _ATW_REGISTERS.mask_dhw
+        | _ATW_REGISTERS.mask_pool
+    )
+
+
+@pytest.mark.asyncio
+async def test_setup_entry_tolerated_gateway_not_ready_registers_optional_devices(
+    hass: HomeAssistant,
+) -> None:
+    """async_setup_entry wiring: tolerated gateway_not_ready + full persisted caps.
+
+    Regression guard for #317. The first refresh is tolerated (returns False),
+    so the real ModbusApiClient keeps an EMPTY ``_data`` and every live
+    ``has_*()`` reads False. The persisted ``system_config`` declares a full
+    reversible unit with DHW + pool + circuit 2. We assert:
+
+      (b/symptom 2) the DHW, Pool and Circuit 2 devices are registered, driven
+        by the persisted fallback rather than the empty live flags;
+      (a/symptom 1) the COP services seeded from the persisted system_config
+        survive -- they are NOT reset to the heating-only no-capability set.
+
+    Pre-fix, the buggy path registered ZERO optional devices and re-initialised
+    the COP services from the all-False live flags (heating only).
+    """
+    entry = MockConfigEntry(
+        version=2,
+        minor_version=4,
+        domain=DOMAIN,
+        title=DEFAULT_NAME,
+        unique_id=f"{DOMAIN}_TESTHW1234",
+        data={
+            "gateway_type": "modbus_atw_mbs_02",
+            "gateway_variant": "gen2",
+            "name": DEFAULT_NAME,
+            CONF_MODBUS_HOST: DEFAULT_HOST,
+            CONF_MODBUS_PORT: DEFAULT_PORT,
+            CONF_MODBUS_DEVICE_ID: DEFAULT_DEVICE_ID,
+            "scan_interval": DEFAULT_SCAN_INTERVAL,
+            "profile": "yutaki_s",
+            "power_supply": DEFAULT_POWER_SUPPLY,
+            # Full reversible unit with DHW + pool + circuit 2, persisted by a
+            # previous successful poll (#308).
+            "system_config": _full_capability_system_config(),
+        },
+        # Telemetry OFF so the noop client is used (no network).
+        options={CONF_TELEMETRY_LEVEL: "off"},
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        # First refresh tolerates gateway_not_ready -> returns False and leaves
+        # the real api_client's _data empty (live has_*() all False).
+        patch(
+            "custom_components.hitachi_yutaki._async_first_refresh_tolerating_gateway_not_ready",
+            AsyncMock(return_value=False),
+        ),
+        # Skip platform setup and recorder-backed restore/rehydrate: this test
+        # targets only the capability wiring, not entity platforms.
+        patch.object(
+            hass.config_entries,
+            "async_forward_entry_setups",
+            AsyncMock(return_value=True),
+        ),
+        patch(
+            "custom_components.hitachi_yutaki._async_restore_thermal_energy",
+            AsyncMock(),
+        ),
+        patch(
+            "custom_components.hitachi_yutaki._async_restore_energy_state",
+            AsyncMock(),
+        ),
+    ):
+        result = await async_setup_entry(hass, entry)
+
+    assert result is True
+
+    coordinator = entry.runtime_data
+
+    # Sanity: the first refresh left the live capabilities empty (the bug's
+    # precondition). If this ever became True, the test would no longer exercise
+    # the stale-data path.
+    assert coordinator.has_dhw() is False
+    assert coordinator.has_pool() is False
+
+    # (b) Symptom 2: optional devices registered from the persisted fallback.
+    device_registry = dr.async_get(hass)
+    for device_key in (DEVICE_DHW, DEVICE_POOL, DEVICE_CIRCUIT_2):
+        identifier = (DOMAIN, f"{entry.entry_id}_{device_key}")
+        assert device_registry.async_get_device(identifiers={identifier}) is not None, (
+            f"expected device {device_key} to be registered from persisted caps"
+        )
+
+    # (a) Symptom 1: COP services seeded from persisted system_config survive.
+    cop_services = coordinator.derived_metrics._cop_services
+    assert "cop_heating" in cop_services
+    assert "cop_cooling" in cop_services
+    assert "cop_dhw" in cop_services
+    assert "cop_pool" in cop_services


### PR DESCRIPTION
Fixes #317.

## Problem

When the first refresh is tolerated through `gateway_not_ready` (#303/#307), `api_client._data` is left empty, so live `has_circuit/has_dhw/has_pool()` all return `False`. The caller in `async_setup_entry` **discarded** the freshness bool returned by `_async_first_refresh_tolerating_gateway_not_ready` and trusted those empty live capabilities, causing:

- **COP services destroyed:** a spurious live-vs-persisted mismatch fired `_init_cop_services(False, False, False)`, wiping the capabilities just seeded from persisted `system_config` (#308).
- **Devices not registered:** DHW/Pool/Circuit device registration, gated on the empty live capabilities, created nothing until a later successful reload.

## Fix

- Capture the freshness bool from the first-refresh helper.
- Two pure, unit-tested helpers:
  - `_resolve_effective_capabilities(data_is_fresh, live, persisted)` → live when fresh, else persisted. Drives all four device-registration gates.
  - `_should_reinit_cop_services(data_is_fresh, live, persisted)` → `False` when not fresh (persisted seeding survives); only `True` when fresh **and** live disagrees with persisted on cooling/dhw/pool.
- Persisted fallback uses the existing decoded flags (`has_circuit1/2_heating|cooling`, `has_dhw`, `has_pool`); circuit gating uses heating-OR-cooling presence.
- Fresh-data path preserved: live capabilities remain authoritative, the mismatch re-init still fires on the same condition. (Live `cooling` now ORs both circuits to match the persisted definition — a latent asymmetry fix.)

## Tests

- New `tests/test_init_gateway_not_ready_capabilities.py`: 6 unit tests on the helpers (all fresh/live/persisted combinations) **plus** an integration test driving the real `async_setup_entry` through a tolerated `gateway_not_ready` with full-capability persisted config, asserting the DHW/Pool/Circuit2 devices are registered and the COP services survive.
- `uv run pytest tests/` → **358 passed** (incl. #303/#307/#308 regression tests). `ruff check` clean.

## Review

Reviewed by an independent fresh agent (adversarial): both symptoms confirmed fixed, helper logic correct for all combinations, no regression on the fresh-data path, the cooling-symmetry change judged a latent-bug fix rather than a risk.

_Found during a systematic multi-agent code audit._
