### PR TITLE
fix(modbus): clear value on 0xFFFF sensor-error instead of keeping stale reading (#320)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Sensors that report a `0xFFFF` sensor-error (e.g. outdoor, water inlet/target temperatures, water flow, compressor temperatures/pressures) now correctly become unavailable instead of retaining their last good value forever. Previously, a register that went to `0xFFFF` with no configured fallback deserialized to `None` and was silently kept in the data cache; the entity kept reporting a frozen reading. A post-deserialization `None` (after any fallback attempt) now clears the stored value, consistent with the existing sentinel-filtered handling (#320).
+
 ### Added
 - Telemetry backend: `backend/grafana/koppen-zones.geojson`, a simplified Köppen-Geiger climate-zone polygon set (29 classes, polar `EF`/`ET` excluded, keyed by `CODE`/`name`) for a climate-zone choropleth panel on the fleet-inventory Grafana dashboard. Active zones are painted with their canonical Köppen family colours (the install count shows in the tooltip and as a per-zone label); zones with no installs stay a neutral, theme-aware grey. Provenance and the `mapshaper` regeneration command are documented in the dashboard design doc.
 

--- a/custom_components/hitachi_yutaki/api/modbus/__init__.py
+++ b/custom_components/hitachi_yutaki/api/modbus/__init__.py
@@ -333,7 +333,12 @@ class ModbusApiClient(HitachiApiClient):
         """Read and deserialize a single register.
 
         Returns the deserialized value, _SENTINEL_FILTERED when the value is a
-        gateway sentinel (unavailable sensor/module), or None on read error.
+        gateway sentinel (unavailable sensor/module), or None when no fresh
+        value is available. None covers both a Modbus read error
+        (``result.isError()``) and a deserializer that maps a sensor-error raw
+        value (e.g. 0xFFFF) to ``None``. Callers must treat a remaining None
+        (after any fallback) as "no value" and clear the stored reading rather
+        than retaining a stale one (see :meth:`read_values`, issue #320).
         """
         result = await self._hass.async_add_executor_job(
             lambda addr=definition.address, param=device_param: (
@@ -447,8 +452,9 @@ class ModbusApiClient(HitachiApiClient):
 
                 for name, definition in registers_to_read.items():
                     value = await self._read_register(definition, device_param)
-                    # Fallback only on read error (None), not on sentinel
-                    # (sentinel = sensor known-absent, no point trying fallback)
+                    # Fallback on any None (read error or a sensor-error raw
+                    # value such as 0xFFFF deserialized to None), but not on
+                    # sentinel (sentinel = module known-absent, no point trying)
                     if value is None and definition.fallback:
                         value = await self._read_register(
                             definition.fallback, device_param
@@ -459,8 +465,15 @@ class ModbusApiClient(HitachiApiClient):
                     elif value is not None:
                         self._data[name] = value
                     else:
+                        # No fresh value: a sensor-error raw value (e.g. 0xFFFF)
+                        # deserialized to None, or a read error, with no working
+                        # fallback. Clear the stored reading so the entity goes
+                        # unavailable instead of reporting a frozen value (#320).
+                        self._data.pop(name, None)
                         _LOGGER.debug(
-                            "Error reading register %s at %s", name, definition.address
+                            "Clearing %s (no fresh value: sensor error or read error at %s)",
+                            name,
+                            definition.address,
                         )
 
                 # Remove data for modules not declared in system_config

--- a/tests/api/modbus/test_client.py
+++ b/tests/api/modbus/test_client.py
@@ -426,6 +426,113 @@ async def test_read_values_resets_throttle_state_on_recovery(
     assert api._gateway_not_ready_last_log == 0.0
 
 
+# --- Stale-value clearing on sensor-error / read-error (issue #320) ---
+
+
+@patch("custom_components.hitachi_yutaki.api.modbus.ir")
+@pytest.mark.asyncio
+async def test_read_values_clears_stale_value_on_sensor_error_without_fallback(
+    _mock_ir, mock_hass, mock_client
+):
+    """A 0xFFFF sensor-error with no fallback must clear the stale value (#320)."""
+    api = _make_preflight_api_client(mock_hass, mock_client)
+    api._data["outdoor_temp"] = 5  # stale good value
+
+    # [preflight system_state, outdoor_temp = 0xFFFF sensor error]
+    mock_client.read_holding_registers.side_effect = [
+        _make_modbus_result(0),
+        _make_modbus_result(0xFFFF),
+    ]
+
+    result = await api.read_values(["outdoor_temp"])
+
+    assert result == ReadResult.SUCCESS
+    assert "outdoor_temp" not in api._data
+
+
+@patch("custom_components.hitachi_yutaki.api.modbus.ir")
+@pytest.mark.asyncio
+async def test_read_values_clears_stale_value_on_read_error_without_fallback(
+    _mock_ir, mock_hass, mock_client
+):
+    """A per-register read error with no fallback must clear the stale value (#320)."""
+    api = _make_preflight_api_client(mock_hass, mock_client)
+    api._data["outdoor_temp"] = 5  # stale good value
+
+    mock_client.read_holding_registers.side_effect = [
+        _make_modbus_result(0),
+        _make_modbus_error(),
+    ]
+
+    result = await api.read_values(["outdoor_temp"])
+
+    assert result == ReadResult.SUCCESS
+    assert "outdoor_temp" not in api._data
+
+
+@patch("custom_components.hitachi_yutaki.api.modbus.ir")
+@pytest.mark.asyncio
+async def test_read_values_keeps_value_on_successful_read(
+    _mock_ir, mock_hass, mock_client
+):
+    """A fresh successful read overwrites the stored value (regression guard)."""
+    api = _make_preflight_api_client(mock_hass, mock_client)
+    api._data["outdoor_temp"] = 5  # stale value to be overwritten
+
+    mock_client.read_holding_registers.side_effect = [
+        _make_modbus_result(0),
+        _make_modbus_result(200),  # convert_signed_16bit(200) == 200
+    ]
+
+    result = await api.read_values(["outdoor_temp"])
+
+    assert result == ReadResult.SUCCESS
+    assert api._data["outdoor_temp"] == 200
+
+
+@patch("custom_components.hitachi_yutaki.api.modbus.ir")
+@pytest.mark.asyncio
+async def test_read_values_fallback_still_recovers_on_sensor_error(
+    _mock_ir, mock_hass, mock_client
+):
+    """Fallback register must still recover when primary is a 0xFFFF sensor-error."""
+    api = _make_preflight_api_client(mock_hass, mock_client)
+
+    # [preflight, primary 1200 = 0xFFFF, fallback 1093 = 350]
+    mock_client.read_holding_registers.side_effect = [
+        _make_modbus_result(0),
+        _make_modbus_result(0xFFFF),
+        _make_modbus_result(350),
+    ]
+
+    result = await api.read_values(["water_outlet_temp"])
+
+    assert result == ReadResult.SUCCESS
+    assert api._data["water_outlet_temp"] == 350
+
+
+@patch("custom_components.hitachi_yutaki.api.modbus.ir")
+@pytest.mark.asyncio
+async def test_read_values_clears_when_both_primary_and_fallback_error(
+    _mock_ir, mock_hass, mock_client
+):
+    """When both primary and fallback error, the stale value must be cleared (#320)."""
+    api = _make_preflight_api_client(mock_hass, mock_client)
+    api._data["water_outlet_temp"] = 42  # stale good value
+
+    # [preflight, primary 1200 = 0xFFFF, fallback 1093 = 0xFFFF]
+    mock_client.read_holding_registers.side_effect = [
+        _make_modbus_result(0),
+        _make_modbus_result(0xFFFF),
+        _make_modbus_result(0xFFFF),
+    ]
+
+    result = await api.read_values(["water_outlet_temp"])
+
+    assert result == ReadResult.SUCCESS
+    assert "water_outlet_temp" not in api._data
+
+
 @pytest.mark.asyncio
 @patch("custom_components.hitachi_yutaki.api.modbus.ir")
 @patch("custom_components.hitachi_yutaki.api.modbus.time")


### PR DESCRIPTION
Fixes #320.

## Problem

Sensors that report a `0xFFFF` sensor-error (e.g. outdoor, water inlet/target temperatures, water flow, compressor temperatures/pressures) kept reporting a frozen, stale reading forever instead of becoming unavailable. When a register went to `0xFFFF` with no configured fallback, the deserializer mapped it to `None`, but `read_values` silently left the previous good value in the data cache, so the entity never reflected the sensor error.

## Fix

In `custom_components/hitachi_yutaki/api/modbus/__init__.py`, a post-deserialization `None` (after any fallback attempt) now clears the stored value via `self._data.pop(name, None)`, so the entity goes unavailable. This is consistent with the existing sentinel-filtered handling. Fallback is now attempted on any `None` (read error or `0xFFFF` deserialized to `None`), but still not on sentinels (module known-absent). The `_read_register` docstring documents the contract, and the debug log message was clarified.

## Tests

Added coverage in `tests/api/modbus/test_client.py` for the 0xFFFF clear-on-error behavior, fallback paths, and sentinel handling.

`uv run pytest tests/api/modbus/test_client.py` -> 29 passed.

## Review

Independently reviewed: APPROVE, no blockers or majors.
