### PR TITLE
fix(modbus): remove duplicate pre-2016 circuit2_thermostat (single global flag at 1029) (#318)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- ATW-MBS-02 (Before Line-up 2016): the "Room Thermostat available" flag is a single global register (address 1029), not a per-circuit control as on the 2016 line-up. The pre-2016 map previously defined `circuit2_thermostat` at the same address 1029 as `circuit1_thermostat`, so toggling circuit 2 silently rewrote the global flag (and shadowed circuit 1). The duplicate `circuit2_thermostat` key has been removed; the flag is now modelled once as `circuit1_thermostat` (#318).
+
 ### Added
 - Telemetry backend: `backend/grafana/koppen-zones.geojson`, a simplified Köppen-Geiger climate-zone polygon set (29 classes, polar `EF`/`ET` excluded, keyed by `CODE`/`name`) for a climate-zone choropleth panel on the fleet-inventory Grafana dashboard. Active zones are painted with their canonical Köppen family colours (the install count shows in the tooltip and as a per-zone label); zones with no installs stay a neutral, theme-aware grey. Provenance and the `mapshaper` regeneration command are documented in the dashboard design doc.
 

--- a/custom_components/hitachi_yutaki/api/modbus/registers/atw_mbs_02_pre2016.py
+++ b/custom_components/hitachi_yutaki/api/modbus/registers/atw_mbs_02_pre2016.py
@@ -181,11 +181,13 @@ REGISTER_CIRCUIT_1 = {
     "circuit1_max_flow_temp_heating_otc": RegisterDefinition(1056, write_address=1007),
     "circuit1_max_flow_temp_cooling_otc": RegisterDefinition(1057, write_address=1008),
     # Pre-2016 hardware (PMML0419A Section 5.2) has a SINGLE global
-    # "Room Thermostat available" flag at address 1029 (doc: 1028 = DHW Mode,
+    # "Room Thermostat available" enable at address 1029 (doc: 1028 = DHW Mode,
     # 1029 = Room Thermostat available). Unlike the 2016 line-up, which splits
-    # the flag into per-circuit registers 1010/1021, pre-2016 exposes only one.
-    # It is modelled once here on circuit 1 (always present); there is no
-    # circuit2_thermostat register on this hardware. See #318.
+    # the enable into per-circuit registers 1010/1021, pre-2016 exposes only
+    # one. (Per-circuit *availability* is still reported read-only via system-
+    # config register 1075 bits 6/7.) It is modelled once here on circuit 1
+    # (always present); there is no per-circuit thermostat *control* register,
+    # hence no circuit2_thermostat on this map. See #318.
     "circuit1_thermostat": RegisterDefinition(1029),
 }
 

--- a/custom_components/hitachi_yutaki/api/modbus/registers/atw_mbs_02_pre2016.py
+++ b/custom_components/hitachi_yutaki/api/modbus/registers/atw_mbs_02_pre2016.py
@@ -180,6 +180,12 @@ REGISTER_CIRCUIT_1 = {
     ),
     "circuit1_max_flow_temp_heating_otc": RegisterDefinition(1056, write_address=1007),
     "circuit1_max_flow_temp_cooling_otc": RegisterDefinition(1057, write_address=1008),
+    # Pre-2016 hardware (PMML0419A Section 5.2) has a SINGLE global
+    # "Room Thermostat available" flag at address 1029 (doc: 1028 = DHW Mode,
+    # 1029 = Room Thermostat available). Unlike the 2016 line-up, which splits
+    # the flag into per-circuit registers 1010/1021, pre-2016 exposes only one.
+    # It is modelled once here on circuit 1 (always present); there is no
+    # circuit2_thermostat register on this hardware. See #318.
     "circuit1_thermostat": RegisterDefinition(1029),
 }
 
@@ -199,7 +205,8 @@ REGISTER_CIRCUIT_2 = {
     ),
     "circuit2_max_flow_temp_heating_otc": RegisterDefinition(1063, write_address=1014),
     "circuit2_max_flow_temp_cooling_otc": RegisterDefinition(1064, write_address=1015),
-    "circuit2_thermostat": RegisterDefinition(1029),
+    # No circuit2_thermostat: pre-2016 has a single global thermostat-available
+    # flag (modelled as circuit1_thermostat at address 1029). See #318.
 }
 
 REGISTER_DHW = {
@@ -252,7 +259,6 @@ WRITABLE_KEYS = {
     "circuit2_otc_calculation_method_cooling",
     "circuit2_max_flow_temp_heating_otc",
     "circuit2_max_flow_temp_cooling_otc",
-    "circuit2_thermostat",
     "circuit2_target_temp",
     "circuit2_current_temp",
     "dhw_power",

--- a/docs/gateway/atw-mbs-02.md
+++ b/docs/gateway/atw-mbs-02.md
@@ -144,6 +144,8 @@ The ATW-MBS-02 has two distinct register maps depending on the Yutaki hardware g
 | 1031 | 1030 | Control Eco offset | 1~10 | R/W |
 | 1032~1050 | 1031~1049 | (Reserved) | — | — |
 
+> **Thermostat availability (pre-2016):** address 1029 ("Room Thermostat available") is a **single global** flag covering all circuits. Unlike the 2016 line-up (which splits the flag into per-circuit registers 1010 / 1021), pre-2016 hardware has no per-circuit thermostat register. The integration models this as `circuit1_thermostat` only; there is no `circuit2_thermostat` on this map (see issue #318).
+
 ### Status Registers (R)
 
 | Register | Address | Description | Range | Type |

--- a/docs/gateway/atw-mbs-02.md
+++ b/docs/gateway/atw-mbs-02.md
@@ -144,7 +144,7 @@ The ATW-MBS-02 has two distinct register maps depending on the Yutaki hardware g
 | 1031 | 1030 | Control Eco offset | 1~10 | R/W |
 | 1032~1050 | 1031~1049 | (Reserved) | — | — |
 
-> **Thermostat availability (pre-2016):** address 1029 ("Room Thermostat available") is a **single global** flag covering all circuits. Unlike the 2016 line-up (which splits the flag into per-circuit registers 1010 / 1021), pre-2016 hardware has no per-circuit thermostat register. The integration models this as `circuit1_thermostat` only; there is no `circuit2_thermostat` on this map (see issue #318).
+> **Thermostat availability (pre-2016):** the *enable* control is global — address 1029 ("Room Thermostat available", R/W) is a **single flag covering all circuits**, unlike the 2016 line-up which splits the enable into per-circuit registers 1010 / 1021. Per-circuit *availability* is still reported read-only via the System Configuration bitfield (reg 1075, bits 6/7 — see [System Configuration Bits (Before 2016)](#system-configuration-bits-before-2016)). The integration therefore models the writable enable as `circuit1_thermostat` only; there is no per-circuit thermostat *control* register, so no `circuit2_thermostat` on this map (see issue #318).
 
 ### Status Registers (R)
 

--- a/tests/api/modbus/registers/test_atw_mbs_02_pre2016.py
+++ b/tests/api/modbus/registers/test_atw_mbs_02_pre2016.py
@@ -89,6 +89,66 @@ class TestPre2016RegisterMap:
         for key in ["dhw_boost", "dhw_high_demand"]:
             assert key not in regs, f"{key} should not exist in before-2016 map"
 
+    def test_no_duplicate_read_addresses(self):
+        """No two distinct semantic keys may share the same read address.
+
+        Pre-2016 (PMML0419A Section 5.2) defines a handful of intentional
+        STATUS/CONTROL aliases (one read register surfaced under two keys).
+        Those are whitelisted below. Any *other* address collision indicates
+        a copy-paste error mapping one key onto an unrelated register --
+        which is exactly the bug behind #318 (circuit2_thermostat duplicated
+        circuit1_thermostat at address 1029).
+        """
+        reg_map = AtwMbs02Pre2016RegisterMap()
+
+        # Documented intentional aliases: each pair is the same physical
+        # register exposed under two keys (a derived/deserialized view plus
+        # the raw value). These legitimately share an address.
+        allowed_alias_pairs = {
+            frozenset({"operation_state", "operation_state_code"}),
+            frozenset({"dhw_antilegionella", "dhw_antilegionella_status"}),
+            frozenset(
+                {"dhw_antilegionella_temp", "dhw_antilegionella_temp_status"}
+            ),
+        }
+
+        by_address: dict[int, list[str]] = {}
+        for key, definition in reg_map.all_registers.items():
+            by_address.setdefault(definition.address, []).append(key)
+
+        for address, keys in by_address.items():
+            if len(keys) == 1:
+                continue
+            assert frozenset(keys) in allowed_alias_pairs, (
+                f"Address {address} is shared by {sorted(keys)}, which is not "
+                f"a documented STATUS/CONTROL alias pair. See #318."
+            )
+
+    def test_single_global_thermostat_register(self):
+        """Pre-2016 has ONE shared 'Room Thermostat available' register.
+
+        Unlike the 2016 line-up (which splits the flag into per-circuit
+        registers 1010/1021), pre-2016 hardware (PMML0419A Section 5.2)
+        exposes a single global flag at address 1029. The integration must
+        therefore model it once -- circuit2_thermostat must not exist (it
+        would silently shadow circuit1_thermostat). See #318.
+        """
+        reg_map = AtwMbs02Pre2016RegisterMap()
+        regs = reg_map.all_registers
+        assert "circuit1_thermostat" in regs
+        assert "circuit2_thermostat" not in regs
+        assert "circuit1_thermostat" in reg_map.writable_keys
+        assert "circuit2_thermostat" not in reg_map.writable_keys
+
+    def test_thermostat_address_correct(self):
+        """The shared thermostat flag sits at address 1029.
+
+        Doc anchor: 1028 = DHW Mode, 1029 = Room Thermostat available
+        (docs/gateway/atw-mbs-02.md, pre-2016 Control section).
+        """
+        reg_map = AtwMbs02Pre2016RegisterMap()
+        assert reg_map.all_registers["circuit1_thermostat"].address == 1029
+
 
 class TestPre2016UnitModelDeserializer:
     """Test the before-2016 unit model deserializer."""

--- a/tests/api/modbus/registers/test_compatibility.py
+++ b/tests/api/modbus/registers/test_compatibility.py
@@ -153,9 +153,9 @@ class TestStatusReadInvariant:
     ATW_MBS_02_PRE2016_EXCEPTIONS = {
         # No Status Unit Run/Stop in pre-2016 (only Status Unit Mode)
         "unit_power",
-        # No STATUS counterpart for "Room thermostat available" pre-2016
+        # Single global "Room thermostat available" flag, no STATUS counterpart
+        # (pre-2016 has only circuit1_thermostat; see #318)
         "circuit1_thermostat",
-        "circuit2_thermostat",
     }
 
     HC_A_MB_EXCEPTIONS = {
@@ -283,3 +283,31 @@ class TestPre2016Specifics:
             ]:
                 key = f"circuit{circuit}_{suffix}"
                 assert key in regs, f"{key} missing from before-2016 map"
+
+    def test_pre2016_single_global_thermostat(self):
+        """Pre-2016 exposes a single global thermostat flag (see #318).
+
+        2016 hardware splits the 'Room Thermostat available' flag into
+        per-circuit registers; pre-2016 has only one. circuit2_thermostat
+        must therefore be absent from the pre-2016 map.
+        """
+        pre = AtwMbs02Pre2016RegisterMap()
+        assert "circuit1_thermostat" in pre.all_registers
+        assert "circuit2_thermostat" not in pre.all_registers
+
+
+class Test2016ThermostatRegisters:
+    """Guard the 2016 per-circuit thermostat split against regression."""
+
+    def test_distinct_per_circuit_addresses(self):
+        """2016 keeps distinct thermostat addresses 1010 / 1021 (see #318).
+
+        Prevents a future change from accidentally collapsing the two
+        per-circuit thermostat registers onto one address (the pre-2016
+        behaviour, which would re-introduce the shadowing bug).
+        """
+        atw = AtwMbs02RegisterMap()
+        regs = atw.all_registers
+        assert regs["circuit1_thermostat"].address == 1010
+        assert regs["circuit2_thermostat"].address == 1021
+        assert regs["circuit1_thermostat"].address != regs["circuit2_thermostat"].address


### PR DESCRIPTION
Fixes #318.

## Problem

On ATW-MBS-02 **pre-2016** hardware (PMML0419A Section 5.2), the "Room Thermostat available" flag is a **single global register at address 1029**, not per-circuit as on the 2016 line-up (which splits it into registers 1010 / 1021).

The pre-2016 register map incorrectly defined `circuit2_thermostat` at the **same address 1029** as `circuit1_thermostat`. Both keys aliased the one physical register, so toggling circuit 2's thermostat silently rewrote the global flag and shadowed circuit 1.

## Fix

- Remove the duplicate `circuit2_thermostat` key (and its `WRITABLE_KEYS` entry) from the pre-2016 map. The flag is now modelled once as `circuit1_thermostat` at address 1029.
- The 2016 line-up is unchanged (it keeps distinct per-circuit registers 1010 / 1021).
- Document the single-global-flag behaviour in `docs/gateway/atw-mbs-02.md`.

## Tests

- New: `test_no_duplicate_read_addresses` (guards against accidental address collisions beyond documented STATUS/CONTROL alias pairs), `test_single_global_thermostat_register`, `test_thermostat_address_correct`, `test_pre2016_single_global_thermostat`, and `Test2016ThermostatRegisters::test_distinct_per_circuit_addresses` (regression guard so 2016 never collapses onto one address).
- `uv run pytest tests/` -> **356 passed, 2 warnings** (pre-existing, unrelated).
- `uv run ruff check custom_components tests` -> **All checks passed!**

This change was independently reviewed (verdict: approve with nits). Review feedback addressed: rebased the branch directly onto `main` so it no longer carries the unrelated #320 fix or clobbers its changelog entry, and reworded the commit subject to accurately describe the key removal (no address is "corrected").
