### PR TITLE
chore(ci): build GitNexus index on main into the Actions cache

### DIFF
--- a/.github/workflows/gitnexus-index.yml
+++ b/.github/workflows/gitnexus-index.yml
@@ -1,0 +1,53 @@
+name: GitNexus Index
+
+# Builds the GitNexus knowledge graph on every push to main and stores it in the
+# GitHub Actions cache. A future PR-review workflow can restore this cache (the
+# default-branch cache is readable from pull requests) and run an incremental
+# `analyze` so an agent can query an index that reflects the PR.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Serialize runs: aborting an analyze mid-flight can corrupt the KuzuDB index.
+concurrency:
+  group: gitnexus-index
+  cancel-in-progress: false
+
+jobs:
+  index:
+    name: Build knowledge graph
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      # Warm the incremental analyze with the most recent index from main.
+      # The exact (sha-keyed) entry never hits, so the prefix restore-key wins.
+      - name: Restore previous index
+        uses: actions/cache/restore@v4
+        with:
+          path: .gitnexus
+          key: gitnexus-index-${{ github.sha }}
+          restore-keys: |
+            gitnexus-index-
+
+      - name: Build / refresh the knowledge graph
+        run: npx --yes gitnexus analyze
+
+      # Only runs if analyze succeeded, so a corrupt/partial index is never cached.
+      - name: Save index to cache
+        uses: actions/cache/save@v4
+        with:
+          path: .gitnexus
+          key: gitnexus-index-${{ github.sha }}


### PR DESCRIPTION
## What

Adds `.github/workflows/gitnexus-index.yml`: on every push to `main` (and via `workflow_dispatch`), builds the GitNexus knowledge graph with `npx gitnexus analyze` and stores `.gitnexus/` in the GitHub Actions cache.

## Why

Lays the producer side for an agent-consumable code index. A future PR-review workflow can restore this cache (the default-branch cache is readable from pull requests) and run an incremental `analyze`, giving an agent an index that reflects the PR.

## Design notes

- **Cache, not commit**: the index is ~146 MB (KuzuDB), far too large to track in git.
- **`cache/restore` + `cache/save` split**: `save` runs only on `analyze` success, so a corrupt/partial index is never cached.
- **Sliding key** `gitnexus-index-<sha>` + `restore-keys: gitnexus-index-`: the exact key never hits, so the prefix restores the latest index and `analyze` only reparses the commit delta (incremental).
- **`concurrency` without cancel**: never abort an in-flight `analyze` (KuzuDB corruption risk).
- No secret required — `analyze` is local (no LLM).

## Notes

- No CHANGELOG entry: internal CI tooling, not user-facing.
- Consumer (PR-review agent) intentionally out of scope, to follow in a separate PR.