### PR TITLE
chore(ci): bump GitNexus workflow actions to v5 (Node 24)

### DIFF
--- a/.github/workflows/gitnexus-index.yml
+++ b/.github/workflows/gitnexus-index.yml
@@ -28,14 +28,14 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "24"
 
       # Warm the incremental analyze with the most recent index from main.
       # The exact (sha-keyed) entry never hits, so the prefix restore-key wins.
       - name: Restore previous index
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: .gitnexus
           key: gitnexus-index-${{ github.sha }}
@@ -47,7 +47,7 @@ jobs:
 
       # Only runs if analyze succeeded, so a corrupt/partial index is never cached.
       - name: Save index to cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: .gitnexus
           key: gitnexus-index-${{ github.sha }}


### PR DESCRIPTION
## What

Bumps the JS actions in `gitnexus-index.yml` to their v5 releases:
- `actions/setup-node@v4` → `@v5`
- `actions/cache/restore@v4` → `@v5`
- `actions/cache/save@v4` → `@v5`

## Why

The first `GitNexus Index` run emitted a deprecation warning: these v4 actions bundle Node.js 20, which GitHub is forcing to Node 24 by default (June 16, 2026) and removing in September 2026. The v5 releases run on Node 24. No behavior change.