### PR TITLE
feat(modbus): log gateway recovery with real not-ready duration (#356)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Logging: the gateway now logs an explicit recovery line (with the real not-ready duration) when its `system_state` transitions back from initializing/desynchronized to synchronized. Previously the recovery was silent in the Modbus layer, so the full outage window (and its true length) was not visible in the logs; only the "not ready" detection and the periodic "still not ready" reminders were. This makes it possible to measure the actual desync windows directly from Home Assistant's logs (#356).
+
 ## [2.1.4] - 2026-06-03
 
 ### Added

--- a/custom_components/hitachi_yutaki/api/modbus/__init__.py
+++ b/custom_components/hitachi_yutaki/api/modbus/__init__.py
@@ -447,6 +447,13 @@ class ModbusApiClient(HitachiApiClient):
 
                 # Gateway is ready - reset throttle state if recovering
                 if self._gateway_not_ready_since is not None:
+                    elapsed = int(time.monotonic() - self._gateway_not_ready_since)
+                    _LOGGER.warning(
+                        "Gateway recovered (state: %s) after being not-ready for %d min %d s.",
+                        raw_state,
+                        elapsed // 60,
+                        elapsed % 60,
+                    )
                     self._gateway_not_ready_since = None
                     self._gateway_not_ready_last_log = 0.0
 

--- a/tests/api/modbus/test_client.py
+++ b/tests/api/modbus/test_client.py
@@ -409,9 +409,9 @@ async def test_read_values_throttles_gateway_not_ready_logs(
 @pytest.mark.asyncio
 @patch("custom_components.hitachi_yutaki.api.modbus.ir")
 async def test_read_values_resets_throttle_state_on_recovery(
-    _mock_ir, mock_hass, mock_client
+    _mock_ir, mock_hass, mock_client, caplog
 ):
-    """Test that throttle state is reset after recovery."""
+    """Test that throttle state is reset and a recovery line is logged (#356)."""
     api = _make_preflight_api_client(mock_hass, mock_client)
 
     # Not ready
@@ -421,9 +421,13 @@ async def test_read_values_resets_throttle_state_on_recovery(
 
     # Recovered
     mock_client.read_holding_registers.return_value = _make_modbus_result(0)
-    await api.read_values(["system_state"])
+    with caplog.at_level(logging.WARNING):
+        caplog.clear()
+        await api.read_values(["system_state"])
     assert api._gateway_not_ready_since is None
     assert api._gateway_not_ready_last_log == 0.0
+    recovery_logs = [r for r in caplog.records if "recovered" in r.message.lower()]
+    assert len(recovery_logs) == 1
 
 
 # --- Stale-value clearing on sensor-error / read-error (issue #320) ---


### PR DESCRIPTION
## What

Adds an explicit `WARNING` log line when the gateway's `system_state` transitions back from initializing/desynchronized to synchronized, reporting the real not-ready duration (`X min Y s`).

## Why

While investigating #356, the reporter's logs showed the gateway dropping (TCP reset + `system_state = 2`) and recovering, but the Modbus layer only logged the *detection* and the periodic "still not ready" reminders, never the recovery. The recovery was silent (the throttle state was reset without a log), so the full outage window and its true length couldn't be measured from HA's logs.

This pairs the recovery line with the existing detection line (both at `WARNING`, so it's visible under the default log config), making the actual desync windows measurable directly from Home Assistant.

The line also fires on flapping (a transient preflight `state = 0` while the full read still fails), which is intentional: it surfaces the gateway oscillating during recovery, exactly the pattern seen in #356.

## Tests

- Extended `test_read_values_resets_throttle_state_on_recovery` to assert the recovery line is emitted.
- Full suite green, lint clean.

Refs #356