### PR TITLE
docs(hc-a-mb): update datasheet to PMML0351 rev.6 and fix outdoor addressing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Docs: refreshed the HC-A(8/16/64)MB datasheet to the official PMML0351 rev.6 (04/2026) and corrected the outdoor-unit register addressing in `docs/gateway/hc-a-mb.md`. The outdoor block is keyed on the **outdoor unit refrigerant cycle** (`30000 + (Cycle × 100) + offset`), not the indoor `Modbus_Id` — the previous `5000 + (Modbus_Id × 200)` formula was wrong (groundwork for #353).
+
 ## [2.1.5] - 2026-06-30
 
 ### Added

--- a/docs/gateway/README.md
+++ b/docs/gateway/README.md
@@ -31,7 +31,7 @@ The original Hitachi PDF documentation is stored in the `datasheets/` subfolder:
 
 - [`ATW-MBS-02_before_line_up_2016.pdf`](datasheets/ATW-MBS-02_before_line_up_2016.pdf) — PMML0419A rev.1 (05/2016), Yutaki series before 2016
 - [`ATW-MBS-02_line_up_2016.pdf`](datasheets/ATW-MBS-02_line_up_2016.pdf) — PMML0419A rev.1 (05/2016), Yutaki 2016 series
-- [`HC-A16MB.pdf`](datasheets/HC-A16MB.pdf) — PMML0351A rev.4 (04/2020), HC-A(8/16/64)MB / HC-A64NET series
+- [`HC-A16MB.pdf`](datasheets/HC-A16MB.pdf) — PMML0351 rev.6 (04/2026), HC-A(8/16/64)MB / HC-A64NET series
 
 ## Integration Register Mapping
 

--- a/docs/gateway/hc-a-mb.md
+++ b/docs/gateway/hc-a-mb.md
@@ -1,6 +1,6 @@
 # HC-A(8/16/64)MB / HC-A64NET — Network / Modbus Gateway Register Map
 
-> Source: PMML0351A rev.4 — 04/2020
+> Source: PMML0351 rev.6 — 04/2026
 
 ## Overview
 
@@ -471,7 +471,7 @@ Offset 145:
 
 Some state registers about outdoor unit have been added. Using these registers it is now possible to know the status of the refrigerant cycle. Some control registers have also been added.
 
-The register address for outdoor units is calculated the same way: `5000 + (Modbus_Id × 200) + Offset`.
+The outdoor unit block uses a **different** base from the indoor block, indexed by the **outdoor unit refrigerant cycle address** (not the indoor `Modbus_Id`): `30000 + (Cycle × 100) + Offset`, where `Cycle` is the outdoor unit cycle refrigerant. Multiple indoor units sharing one outdoor unit therefore read the same outdoor block (same cycle); independent systems on distinct cycles read distinct blocks (cycle 0 → 30000, cycle 1 → 30100, ...).
 
 | Offset | Description | Values | R/W |
 |---|---|---|---|


### PR DESCRIPTION
## What

- Replaces the bundled HC-A(8/16/64)MB datasheet with the official **PMML0351 rev.6 (04/2026)** (was rev.4, 04/2020).
- Corrects the outdoor-unit register addressing in `docs/gateway/hc-a-mb.md`.

## Why

While investigating #353 (Primary Compressor data wrong when multiple outdoor units share one HC-A gateway), the bundled rev.4 datasheet turned out to predate the explicit outdoor addressing note. Rev.6 §5.3 states it directly:

> Register address is calculated as: `30000 + (Address × 100) + offset` — Address is outdoor unit cycle refrigerant.

Our `hc-a-mb.md` previously documented the outdoor block as `5000 + (Modbus_Id × 200) + offset`, which is wrong on two counts: the base is `30000`, and it scales by the **refrigerant cycle**, not the indoor `Modbus_Id`. This is documentation-only groundwork; the actual code fix in `_outdoor_addr` is tracked separately under #353 (pending a hardware scan to confirm the per-cycle layout).

Rev.6 also adds outdoor offset 18 (`Power Control Possible`) and a new §5.4 Optional Functions block — noted for future register work, not mapped here.

## Scope

Docs only. No code changes.

Refs #353