### PR TITLE
docs: clarify power_consumption/electrical_power are compressor-only estimates (#373)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Docs: clarified that `electrical_power` and `power_consumption` are compressor-only estimates (`P ≈ U × I × cosφ`), not full-unit measurements. They exclude the electric backup/immersion heater, pumps, fan and standby loads, so they structurally under-report (notably on Yutampo/DHW-only setups); a configured **Power Sensor** takes priority and yields accurate readings. Fixed the misleading "Total electrical energy consumed by the unit" description in `docs/reference/entities.md` and documented the scope in `docs/reference/domain-services.md` (#373).
+
 ## [2.2.0-beta.1] - 2026-07-21
 
 ### Fixed

--- a/docs/reference/domain-services.md
+++ b/docs/reference/domain-services.md
@@ -168,6 +168,14 @@ Historical states can be preloaded from the Recorder for continuity across resta
 Estimates electrical power consumption from compressor current with a priority
 chain for input data.
 
+> **Scope:** when no measured power is available, the estimate covers the
+> **compressor only**. It does not account for the electric backup/immersion
+> heater, circulation pumps, fan, or standby loads, and assumes a fixed
+> `cos(phi) = 0.9` and default voltage. On Yutampo/DHW-only units, where the
+> electric heater carries much of the load, this can under-report by an order of
+> magnitude. A configured `measured_power` (Power Sensor option) bypasses the
+> estimate entirely (priority 1).
+
 ### Priority
 
 1. `measured_power` (direct kW reading, if available)

--- a/docs/reference/entities.md
+++ b/docs/reference/entities.md
@@ -68,9 +68,19 @@ Only one of these two selects is created per install (mutually exclusive): `oper
 
 | Entity | Type | Description | Unit | Category |
 |--------|------|-------------|------|----------|
-| electrical_power | sensor | Real-time electrical power drawn by the unit (always present) | kW | - |
-| power_consumption | sensor | Total electrical energy consumed by the unit | kWh | - |
+| electrical_power | sensor | Real-time electrical power, estimated from compressor current (see note below) | kW | - |
+| power_consumption | sensor | Cumulative electrical energy, integrated from `electrical_power` (see note below) | kWh | - |
 | electricity_cost | sensor | Cumulative electricity cost (only when an electricity price entity is configured) | currency | - |
+
+> **Note:** unless a **Power Sensor** is configured, `electrical_power` and
+> `power_consumption` are **estimates** computed from the compressor running
+> current only (`P ≈ U × I × cosφ`). They do **not** include the electric
+> backup/immersion heater, circulation pumps, fan, or standby loads, so they
+> structurally under-report, especially on Yutampo/DHW-only setups where the
+> electric heater does much of the work. For accurate readings, wire a real
+> power meter to the optional **Power Sensor** option (config flow): a measured
+> value takes priority over the estimate for both these sensors and the COP
+> calculation.
 
 ### Thermal Energy
 


### PR DESCRIPTION
## What

Clarifies in the docs that `electrical_power` and `power_consumption` are **compressor-only estimates** (`P ≈ U × I × cosφ`), not full-unit measurements.

## Why

Reported in #373: on a Yutampo R32, the integration's power/energy reads ~10x lower than independent meters (Shelly 2PM on outdoor unit + immersion heater). Root cause is not a bug but expectation-setting: the estimate is derived from the compressor running current only, so it ignores the electric backup/immersion heater, pumps, fan and standby loads. On DHW-only units where the electric heater carries much of the load, this under-reports by an order of magnitude.

The user-facing entity reference actively mislabeled the sensor as *"Total electrical energy consumed by the unit"*, which is the opposite of the truth.

## Changes

- `docs/reference/entities.md`: re-describe `electrical_power` and `power_consumption`; fix the misleading "Total…" wording; add a **Note** on the exclusions and on the optional **Power Sensor** option (which takes priority and yields accurate readings for both sensors and COP).
- `docs/reference/domain-services.md`: add a **Scope** block to the Electrical Power service.
- `CHANGELOG.md`: entry under `[Unreleased] > Changed`.

Docs-only. No code change.

Closes #373
