### PR TITLE
feat: refrigerant-circuit anomaly detection (slow charge loss)

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -68,6 +68,12 @@ See [docs/reference/domain-services.md](docs/reference/domain-services.md) for d
 - Separate tracking for heating and cooling (real-time power, daily energy, total energy).
 - **Defrost filtering** and **post-cycle lock** prevent measurement noise.
 
+### Refrigerant Anomaly Detection
+- Continuous, local early-warning for a **slow refrigerant charge loss** (`domain/services/refrigerant.py`, `RefrigerantMonitor`). Advisory only; complements, does not replace, the mandatory F-Gas inspection.
+- Tracks the joint drift of suction superheat (`Tg − Te`) and outdoor expansion-valve opening (`EVO`) against a per-installation baseline learned over ~2 weeks; superheat is the season-robust primary signal, `EVO` is compared only at equivalent outdoor temperature.
+- Surfaces `sensor.*_refrigerant_charge_status` (ENUM `learning`/`ok`/`watch`/`alert`), a `Reset Refrigerant Baseline` button, and a self-clearing repair issue on sustained alert. Baseline persists via a HA `Store`. Gated on `supports_extended_compressor_sensors` (excludes Yutampo R32).
+- See [docs/reference/refrigerant-monitoring.md](docs/reference/refrigerant-monitoring.md).
+
 ### Anonymous Telemetry
 - Binary consent (Off / On) stored in `entry.options["telemetry_level"]` (`CONF_TELEMETRY_LEVEL`, default `"off"`).
 - **Package** (`telemetry/`): models (three payloads: `InstallationInfo`, `MetricsBatch`, `RegisterSnapshot`), collector (circular buffer), anonymizer (SHA-256 hash, temperature/geolocation rounding), HTTP client (gzip + retry), noop client.
@@ -178,6 +184,6 @@ The PR checklist ([.github/pull_request_template.md](.github/pull_request_templa
 ## Documentation Index
 - [Architecture](docs/architecture.md): hexagonal layers, data flow, domain matrix.
 - [Development guides](docs/development/): getting started, adding entities, registers/data keys, profiles, telemetry dataset.
-- [Reference](docs/reference/): entity reference, entity patterns, domain services, quality scale, telemetry, model nomenclature.
+- [Reference](docs/reference/): entity reference, entity patterns, domain services, refrigerant monitoring, quality scale, telemetry, model nomenclature.
 - [Gateway docs](docs/gateway/): register maps, scan reference, sentinel values, datasheets.
 - [Troubleshooting](docs/troubleshooting.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Refrigerant-circuit anomaly detection (first iteration): a continuous, local early-warning for a **slow refrigerant charge loss**, built from the compressor signals the integration already reads. A new diagnostic sensor `Refrigerant Charge Status` (`learning`/`ok`/`watch`/`alert`, on the Primary Compressor device) tracks the joint drift of suction superheat (`Tg − Te`) and the outdoor expansion-valve opening (`EVO`) against a per-installation baseline learned over ~2 weeks of heating; superheat (a regulated, season-robust quantity) is the primary signal and `EVO` is only compared at equivalent outdoor temperature to avoid weather-driven false alarms. A self-clearing repair issue is raised when the alert persists for several days, and a `Reset Refrigerant Baseline` button re-learns the reference after a refrigerant top-up or expansion-valve service. The baseline persists across restarts. Advisory only — it **complements** and does **not** replace the mandatory F-Gas leak-tightness inspection. Available on all profiles with extended compressor sensors (every model except the Yutampo R32). See [docs/reference/refrigerant-monitoring.md](docs/reference/refrigerant-monitoring.md) (#310).
+
 ## [2.2.0-beta.1] - 2026-07-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0-beta.2] - 2026-07-22
+
 ### Added
 - Refrigerant-circuit anomaly detection (first iteration): a continuous, local early-warning for a **slow refrigerant charge loss**, built from the compressor signals the integration already reads. A new diagnostic sensor `Refrigerant Charge Status` (`learning`/`ok`/`watch`/`alert`, on the Primary Compressor device) tracks the joint drift of suction superheat (`Tg − Te`) and the outdoor expansion-valve opening (`EVO`) against a per-installation baseline learned over ~2 weeks of heating; superheat (a regulated, season-robust quantity) is the primary signal and `EVO` is only compared at equivalent outdoor temperature to avoid weather-driven false alarms. A self-clearing repair issue is raised when the alert persists for several days, and a `Reset Refrigerant Baseline` button re-learns the reference after a refrigerant top-up or expansion-valve service. The baseline persists across restarts. Advisory only — it **complements** and does **not** replace the mandatory F-Gas leak-tightness inspection. Available on all profiles with extended compressor sensors (every model except the Yutampo R32). See [docs/reference/refrigerant-monitoring.md](docs/reference/refrigerant-monitoring.md) (#310).
 

--- a/custom_components/hitachi_yutaki/__init__.py
+++ b/custom_components/hitachi_yutaki/__init__.py
@@ -459,6 +459,7 @@ async def async_setup_entry(
         has_dhw=persisted_has_dhw,
         has_pool=persisted_has_pool,
         supports_secondary_compressor=profile.supports_secondary_compressor,
+        supports_extended_compressor_sensors=profile.supports_extended_compressor_sensors,
     )
 
     # Initial poll. A transient gateway_not_ready (H-LINK still initializing
@@ -522,6 +523,9 @@ async def async_setup_entry(
 
     # Rehydrate compressor timing from Recorder history
     await coordinator.derived_metrics.async_rehydrate_timing()
+
+    # Restore refrigerant-anomaly detector state from its persisted Store
+    await coordinator.derived_metrics.async_restore_refrigerant()
 
     _LOGGER.info("Using Hitachi profile: %s", profile.name)
 
@@ -754,6 +758,10 @@ async def async_unload_entry(
 
         # Flush remaining telemetry data before closing
         await coordinator.async_flush_telemetry()
+
+        # Persist refrigerant detector state before closing
+        if coordinator.derived_metrics is not None:
+            await coordinator.derived_metrics.async_flush_refrigerant()
 
         # Close API connection
         if coordinator.api_client.connected:

--- a/custom_components/hitachi_yutaki/adapters/derived_metrics.py
+++ b/custom_components/hitachi_yutaki/adapters/derived_metrics.py
@@ -14,6 +14,8 @@ import logging
 import time
 from typing import Any
 
+from homeassistant.helpers.storage import Store
+
 from ..adapters.calculators.electrical import ElectricalPowerCalculatorAdapter
 from ..adapters.calculators.thermal import (
     thermal_power_calculator_cooling_wrapper,
@@ -36,6 +38,7 @@ from ..const import (
 )
 from ..domain.models.cop import COPInput
 from ..domain.models.operation import MODE_COOLING, MODE_DHW, MODE_HEATING, MODE_POOL
+from ..domain.models.refrigerant import RefrigerantInput, RefrigerantStatus
 from ..domain.services.cop import (
     COP_MEASUREMENTS_HISTORY_SIZE,
     COP_MEASUREMENTS_PERIOD,
@@ -43,12 +46,19 @@ from ..domain.services.cop import (
     EnergyAccumulator,
 )
 from ..domain.services.defrost_guard import DefrostGuard
+from ..domain.services.refrigerant import (
+    HISTORY_DAYS as REFRIGERANT_HISTORY_DAYS,
+    RefrigerantMonitor,
+)
 from ..domain.services.thermal import ThermalEnergyAccumulator, ThermalPowerService
 from ..domain.services.timing import CompressorHistory, CompressorTimingService
 
 _LOGGER = logging.getLogger(__name__)
 
 COMPRESSOR_HISTORY_SIZE = 100
+
+REFRIGERANT_STORE_VERSION = 1
+REFRIGERANT_SAVE_DELAY_S = 600  # debounce persisted writes (flush is daily)
 
 
 class DerivedMetricsAdapter:
@@ -63,6 +73,7 @@ class DerivedMetricsAdapter:
         has_dhw: bool = False,
         has_pool: bool = False,
         supports_secondary_compressor: bool = False,
+        supports_extended_compressor_sensors: bool = False,
     ) -> None:
         """Initialize the adapter with domain services."""
         self._hass = hass
@@ -112,6 +123,22 @@ class DerivedMetricsAdapter:
         self._last_energy_time: float | None = None
         self._accumulated_energy: float = 0.0  # kWh integrated from electrical_power
         self._electricity_cost: float = 0.0
+
+        # Refrigerant-circuit anomaly detection (extended-sensor profiles only)
+        self._refrigerant_monitor: RefrigerantMonitor | None = None
+        self._refrigerant_store: Store | None = None
+        self._refrigerant_status: RefrigerantStatus | None = None
+        if supports_extended_compressor_sensors:
+            self._refrigerant_monitor = RefrigerantMonitor(
+                InMemoryStorage(max_len=REFRIGERANT_HISTORY_DAYS)
+            )
+            entry_id = getattr(config_entry, "entry_id", None)
+            if hass is not None and entry_id:
+                self._refrigerant_store = Store(
+                    hass,
+                    REFRIGERANT_STORE_VERSION,
+                    f"{DOMAIN}_refrigerant_{entry_id}",
+                )
 
     def _make_cop_service(
         self, thermal_calculator: Any, expected_mode: str
@@ -166,6 +193,7 @@ class DerivedMetricsAdapter:
         self._update_cop(data)
         self._update_energy(data)
         self._update_timing(data)
+        self._update_refrigerant(data)
 
     def _get_temperature(
         self, data: dict[str, Any], config_key: str, fallback_key: str
@@ -514,6 +542,81 @@ class DerivedMetricsAdapter:
             data["secondary_compressor_cycle_time"] = sec_timing.cycle_time
             data["secondary_compressor_runtime"] = sec_timing.runtime
             data["secondary_compressor_resttime"] = sec_timing.resttime
+
+    def _update_refrigerant(self, data: dict[str, Any]) -> None:
+        """Feed the refrigerant monitor and inject its verdict into data."""
+        monitor = self._refrigerant_monitor
+        if monitor is None:
+            return
+
+        refrigerant_input = RefrigerantInput(
+            operation_mode=resolve_operation_mode(data.get("operation_state")),
+            compressor_frequency=data.get("compressor_frequency"),
+            gas_temp=data.get("compressor_tg_gas_temp"),
+            evaporator_temp=data.get("compressor_te_evaporator_temp"),
+            outdoor_expansion_valve=data.get(
+                "compressor_evo_outdoor_expansion_valve_opening"
+            ),
+            outdoor_temp=data.get("outdoor_temp"),
+            data_reliable=self.defrost_guard.is_data_reliable,
+        )
+
+        flushed = monitor.update(refrigerant_input)
+        status = monitor.get_status()
+        self._refrigerant_status = status
+
+        data["refrigerant_charge_status"] = status.status
+        data["refrigerant_charge_superheat_delta"] = status.superheat_delta
+        data["refrigerant_charge_exv_delta"] = status.exv_delta
+        data["refrigerant_charge_evaporation_temp_delta"] = (
+            status.evaporation_temp_delta
+        )
+        data["refrigerant_charge_baseline_days"] = (
+            status.baseline.days if status.baseline else None
+        )
+        data["refrigerant_charge_valid_days"] = status.valid_days
+        data["refrigerant_charge_alert_streak"] = status.alert_streak
+
+        # A daily flush changed the persisted state — schedule a debounced save.
+        if flushed and self._refrigerant_store is not None:
+            self._refrigerant_store.async_delay_save(
+                monitor.serialize, REFRIGERANT_SAVE_DELAY_S
+            )
+
+    @property
+    def refrigerant_status(self) -> RefrigerantStatus | None:
+        """Return the latest refrigerant verdict (None until first computed)."""
+        return self._refrigerant_status
+
+    async def async_restore_refrigerant(self) -> None:
+        """Load persisted refrigerant state from the Store into the monitor."""
+        if self._refrigerant_monitor is None or self._refrigerant_store is None:
+            return
+        try:
+            state = await self._refrigerant_store.async_load()
+        except Exception:  # noqa: BLE001
+            _LOGGER.debug("Failed to load refrigerant state", exc_info=True)
+            return
+        if state:
+            self._refrigerant_monitor.restore(state)
+
+    async def async_reset_refrigerant(self) -> None:
+        """Clear the monitor and delete its persisted state."""
+        if self._refrigerant_monitor is not None:
+            self._refrigerant_monitor.reset()
+            self._refrigerant_status = None
+        if self._refrigerant_store is not None:
+            await self._refrigerant_store.async_remove()
+
+    async def async_flush_refrigerant(self) -> None:
+        """Persist the current refrigerant state immediately (e.g. on unload)."""
+        if (
+            self._refrigerant_monitor is not None
+            and self._refrigerant_store is not None
+        ):
+            await self._refrigerant_store.async_save(
+                self._refrigerant_monitor.serialize()
+            )
 
     async def async_rehydrate_timing(self) -> None:
         """Replay Recorder data to rebuild compressor timing history."""

--- a/custom_components/hitachi_yutaki/button.py
+++ b/custom_components/hitachi_yutaki/button.py
@@ -8,6 +8,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from . import HitachiYutakiConfigEntry
 
 # Import builders from domain entities
+from .entities.compressor import build_refrigerant_buttons
 from .entities.dhw import build_dhw_buttons
 
 
@@ -24,5 +25,9 @@ async def async_setup_entry(
     # DHW buttons
     if coordinator.has_dhw():
         entities.extend(build_dhw_buttons(coordinator, entry.entry_id))
+
+    # Refrigerant detector reset button (extended-sensor profiles only)
+    if coordinator.profile.supports_extended_compressor_sensors:
+        entities.extend(build_refrigerant_buttons(coordinator, entry.entry_id))
 
     async_add_entities(entities)

--- a/custom_components/hitachi_yutaki/coordinator.py
+++ b/custom_components/hitachi_yutaki/coordinator.py
@@ -30,6 +30,9 @@ from .const import (
     DOMAIN,
 )
 from .domain.services.defrost_guard import DefrostGuard
+from .domain.services.refrigerant import (
+    ALERT_PERSIST_DAYS as REFRIGERANT_ALERT_PERSIST_DAYS,
+)
 from .profiles import HitachiHeatPumpProfile
 from .telemetry import (
     HttpTelemetryClient,
@@ -177,6 +180,7 @@ class HitachiYutakiDataCoordinator(DataUpdateCoordinator):
             # Enrich data with derived metrics (thermal power, COP, timing)
             if self.derived_metrics is not None:
                 self.derived_metrics.update(data)
+                self._update_refrigerant_issue()
 
             # If we reach here, connection is successful, so delete any connection error issue
             ir.async_delete_issue(self.hass, DOMAIN, "connection_error")
@@ -365,3 +369,35 @@ class HitachiYutakiDataCoordinator(DataUpdateCoordinator):
     def has_pool(self) -> bool:
         """Return True if pool heating is configured in system_config."""
         return self.api_client.has_pool
+
+    def _refrigerant_issue_id(self) -> str:
+        """Return the repair-issue id for the refrigerant charge alert."""
+        return f"refrigerant_charge_alert_{self.config_entry.entry_id}"
+
+    def _update_refrigerant_issue(self) -> None:
+        """Raise or clear the refrigerant charge alert repair issue.
+
+        Self-clearing advisory (WARNING, non-fixable): raised once the alert has
+        persisted for several days, deleted as soon as the verdict recovers. It
+        complements and does not replace the mandatory F-Gas inspection.
+        """
+        status = getattr(self.derived_metrics, "refrigerant_status", None)
+        issue_id = self._refrigerant_issue_id()
+        if status is not None and status.alert_streak >= REFRIGERANT_ALERT_PERSIST_DAYS:
+            ir.async_create_issue(
+                self.hass,
+                DOMAIN,
+                issue_id,
+                is_fixable=False,
+                is_persistent=False,
+                severity=ir.IssueSeverity.WARNING,
+                translation_key="refrigerant_charge_alert",
+            )
+        else:
+            ir.async_delete_issue(self.hass, DOMAIN, issue_id)
+
+    async def async_reset_refrigerant_baseline(self) -> None:
+        """Reset the refrigerant detector baseline (after a top-up or service)."""
+        if self.derived_metrics is not None:
+            await self.derived_metrics.async_reset_refrigerant()
+        ir.async_delete_issue(self.hass, DOMAIN, self._refrigerant_issue_id())

--- a/custom_components/hitachi_yutaki/domain/models/refrigerant.py
+++ b/custom_components/hitachi_yutaki/domain/models/refrigerant.py
@@ -1,0 +1,61 @@
+"""Refrigerant-circuit anomaly detection domain models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import NamedTuple
+
+
+@dataclass
+class RefrigerantInput:
+    """One poll's worth of refrigerant-circuit signals.
+
+    All numeric fields are optional because the gateway may return ``None`` for
+    a register (read error, sentinel, or 0xFFFF). ``data_reliable`` mirrors the
+    defrost guard: the sample is only usable when the reading is trustworthy.
+    """
+
+    operation_mode: str | None
+    compressor_frequency: float | None
+    gas_temp: float | None  # Tg, suction gas temperature (°C)
+    evaporator_temp: float | None  # Te, evaporating/saturation temperature (°C)
+    outdoor_expansion_valve: float | None  # EVO opening (%)
+    outdoor_temp: float | None  # outdoor ambient temperature (°C)
+    data_reliable: bool = True
+
+
+class DailyAggregate(NamedTuple):
+    """Robust per-day summary of qualifying refrigerant samples."""
+
+    day: date
+    superheat: float  # median suction superheat Tg - Te (K)
+    evaporation_temp: float  # median Te (°C)
+    exv: float  # median EVO opening (%)
+    outdoor_temp: float  # median outdoor ambient (°C)
+    sample_count: int
+
+
+@dataclass
+class RefrigerantBaseline:
+    """Frozen reference established from the first valid days."""
+
+    superheat: float
+    evaporation_temp: float
+    exv: float
+    outdoor_temp: float
+    days: int
+
+
+@dataclass
+class RefrigerantStatus:
+    """Current detector verdict, surfaced to the diagnostic entity."""
+
+    status: str  # learning / ok / watch / alert
+    superheat_delta: float | None
+    exv_delta: float | None  # None when no temperature-matched recent days
+    evaporation_temp_delta: float | None
+    baseline: RefrigerantBaseline | None
+    valid_days: int
+    today_samples: int
+    alert_streak: int

--- a/custom_components/hitachi_yutaki/domain/services/__init__.py
+++ b/custom_components/hitachi_yutaki/domain/services/__init__.py
@@ -1,6 +1,7 @@
 """Domain services for Hitachi Yutaki."""
 
 from .cop import COPService, EnergyAccumulator
+from .refrigerant import RefrigerantMonitor
 from .thermal import ThermalEnergyAccumulator, ThermalPowerService
 from .timing import CompressorHistory, CompressorTimingService
 
@@ -16,6 +17,7 @@ COP_OPTIMAL_TIME_SPAN = 15  # minutes
 __all__ = [
     "COPService",
     "EnergyAccumulator",
+    "RefrigerantMonitor",
     "ThermalEnergyAccumulator",
     "ThermalPowerService",
     "CompressorHistory",

--- a/custom_components/hitachi_yutaki/domain/services/refrigerant.py
+++ b/custom_components/hitachi_yutaki/domain/services/refrigerant.py
@@ -1,0 +1,347 @@
+"""Refrigerant-circuit anomaly detection service.
+
+Detects a slow refrigerant charge loss between two mandatory F-Gas leak-tightness
+inspections. It **complements** and does not replace the legal inspection.
+
+Pure business logic, isolated from Home Assistant. Mirrors the COP service:
+optional ``timestamp`` for replay/tests and ``time()`` for the sample-interval
+throttle. See ``docs/reference/refrigerant-monitoring.md`` for the rationale.
+
+Physical basis: a slow undercharge raises suction superheat ``SH = Tg - Te`` and
+drives the expansion valve (EVO) further open to compensate, while the
+evaporating temperature ``Te`` drifts down. Superheat is a *regulated* quantity,
+so it is robust to seasonal variation; EVO and Te are not, and are compared only
+at equivalent outdoor temperature (EVO) or reported for information (Te).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import date, datetime
+from statistics import median
+from time import time
+from typing import Any
+
+from ..models.operation import MODE_HEATING
+from ..models.refrigerant import (
+    DailyAggregate,
+    RefrigerantBaseline,
+    RefrigerantInput,
+    RefrigerantStatus,
+)
+from ..ports.storage import Storage
+
+# Sampling gate
+SAMPLE_MIN_INTERVAL_S = 60  # at most one sample per minute (like COP)
+MIN_FREQUENCY = 20.0  # Hz — skip idle and very-low-load startup noise
+MAX_FREQUENCY = 150.0  # Hz — keep load roughly comparable
+
+# Plausibility bounds (a sample outside any bound is discarded)
+SUPERHEAT_MIN_K = -10.0
+SUPERHEAT_MAX_K = 40.0
+EVO_MIN_PCT = 0.0
+EVO_MAX_PCT = 100.0  # datasheet range; also guards EVO's 0xFFFF (=65535) case
+EVAP_MIN_C = -60.0
+EVAP_MAX_C = 40.0
+OUTDOOR_MIN_C = -40.0
+OUTDOOR_MAX_C = 40.0
+
+# Daily aggregation
+MIN_SAMPLES_PER_DAY = 30  # ~30 min of qualifying heating for a "valid" day
+HISTORY_DAYS = 45  # rolling window of daily aggregates
+
+# Baseline / evaluation
+BASELINE_DAYS = 14  # valid days needed to freeze the baseline
+EVAL_DAYS = 7  # trailing valid days forming the recent window
+MIN_EVAL_DAYS = 3  # minimum recent days before a verdict beyond `ok`
+TEMP_MATCH_K = 4.0  # outdoor-temperature band for the EVO comparison
+
+# Thresholds (heuristic, conservative)
+SUPERHEAT_WATCH_K = 3.0
+SUPERHEAT_ALERT_K = 5.0
+EVO_ALERT_PCT = 15.0
+
+# Alert persistence before a repair issue is raised
+ALERT_PERSIST_DAYS = 3
+
+# Status values (also the ENUM options of the diagnostic sensor)
+STATUS_LEARNING = "learning"
+STATUS_OK = "ok"
+STATUS_WATCH = "watch"
+STATUS_ALERT = "alert"
+
+
+class RefrigerantMonitor:
+    """Accumulates daily refrigerant statistics and detects a slow charge loss.
+
+    The service is independent of Home Assistant and infrastructure concerns.
+    Daily aggregates (one per day) are held in the injected ``Storage`` so weeks
+    of history cost a handful of records; intra-day samples live in a transient
+    in-memory buffer that is intentionally not persisted.
+    """
+
+    def __init__(self, storage: Storage[DailyAggregate]) -> None:
+        """Initialize the monitor with a bounded daily-aggregate storage."""
+        self._storage = storage
+        self._baseline: RefrigerantBaseline | None = None
+        self._alert_streak = 0
+
+        # Transient intra-day buffers (volatile across restarts).
+        self._current_day: date | None = None
+        self._superheats: list[float] = []
+        self._evos: list[float] = []
+        self._evaps: list[float] = []
+        self._outdoors: list[float] = []
+        self._last_sample_time = 0.0
+
+    def update(
+        self, data: RefrigerantInput, *, timestamp: datetime | None = None
+    ) -> bool:
+        """Feed one poll of signals.
+
+        Returns ``True`` when a daily aggregate was just flushed (a cue for the
+        adapter to persist the serialized state).
+        """
+        now = timestamp or datetime.now()
+        today = now.date()
+
+        flushed = False
+        if self._current_day is None:
+            self._current_day = today
+        elif today != self._current_day:
+            flushed = self._flush_day()
+            self._current_day = today
+
+        if not self._should_sample(data):
+            return flushed
+
+        # Throttle: at most one sample per interval.
+        current = time()
+        if current - self._last_sample_time < SAMPLE_MIN_INTERVAL_S:
+            return flushed
+
+        superheat = data.gas_temp - data.evaporator_temp  # type: ignore[operator]
+        if not (SUPERHEAT_MIN_K <= superheat <= SUPERHEAT_MAX_K):
+            return flushed
+        if not (EVO_MIN_PCT <= data.outdoor_expansion_valve <= EVO_MAX_PCT):  # type: ignore[operator]
+            return flushed
+        if not (EVAP_MIN_C <= data.evaporator_temp <= EVAP_MAX_C):  # type: ignore[operator]
+            return flushed
+        if not (OUTDOOR_MIN_C <= data.outdoor_temp <= OUTDOOR_MAX_C):  # type: ignore[operator]
+            return flushed
+
+        self._last_sample_time = current
+        self._superheats.append(superheat)
+        self._evos.append(data.outdoor_expansion_valve)  # type: ignore[arg-type]
+        self._evaps.append(data.evaporator_temp)  # type: ignore[arg-type]
+        self._outdoors.append(data.outdoor_temp)  # type: ignore[arg-type]
+        return flushed
+
+    def get_status(self) -> RefrigerantStatus:
+        """Return the current detector verdict."""
+        return self._evaluate()
+
+    def serialize(self) -> dict[str, Any]:
+        """Return a JSON-serializable snapshot of the persistent state."""
+        return {
+            "baseline": (
+                None
+                if self._baseline is None
+                else {
+                    "superheat": self._baseline.superheat,
+                    "evaporation_temp": self._baseline.evaporation_temp,
+                    "exv": self._baseline.exv,
+                    "outdoor_temp": self._baseline.outdoor_temp,
+                    "days": self._baseline.days,
+                }
+            ),
+            "alert_streak": self._alert_streak,
+            "aggregates": [
+                {
+                    "day": aggregate.day.isoformat(),
+                    "superheat": aggregate.superheat,
+                    "evaporation_temp": aggregate.evaporation_temp,
+                    "exv": aggregate.exv,
+                    "outdoor_temp": aggregate.outdoor_temp,
+                    "sample_count": aggregate.sample_count,
+                }
+                for aggregate in self._storage.get_all()
+            ],
+        }
+
+    def restore(self, state: dict[str, Any] | None) -> None:
+        """Restore persistent state from a serialized snapshot."""
+        if not state:
+            return
+
+        # Full reset first, so restoring onto any monitor is idempotent.
+        self._baseline = None
+        self._current_day = None
+        self._reset_day_buffers()
+        while len(self._storage):
+            self._storage.popleft()
+
+        baseline = state.get("baseline")
+        if baseline:
+            self._baseline = RefrigerantBaseline(
+                superheat=baseline["superheat"],
+                evaporation_temp=baseline["evaporation_temp"],
+                exv=baseline["exv"],
+                outdoor_temp=baseline["outdoor_temp"],
+                days=baseline.get("days", BASELINE_DAYS),
+            )
+        self._alert_streak = state.get("alert_streak", 0)
+
+        for item in state.get("aggregates", []):
+            self._storage.append(
+                DailyAggregate(
+                    day=date.fromisoformat(item["day"]),
+                    superheat=item["superheat"],
+                    evaporation_temp=item["evaporation_temp"],
+                    exv=item["exv"],
+                    outdoor_temp=item["outdoor_temp"],
+                    sample_count=item["sample_count"],
+                )
+            )
+
+    def reset(self) -> None:
+        """Clear all state (used after a refrigerant top-up or EXV service)."""
+        self._baseline = None
+        self._alert_streak = 0
+        self._current_day = None
+        self._reset_day_buffers()
+        while len(self._storage):
+            self._storage.popleft()
+
+    def _flush_day(self) -> bool:
+        """Aggregate the finished day, freeze the baseline, update the streak."""
+        count = len(self._superheats)
+        added = False
+        if count >= MIN_SAMPLES_PER_DAY and self._current_day is not None:
+            self._storage.append(
+                DailyAggregate(
+                    day=self._current_day,
+                    superheat=median(self._superheats),
+                    evaporation_temp=median(self._evaps),
+                    exv=median(self._evos),
+                    outdoor_temp=median(self._outdoors),
+                    sample_count=count,
+                )
+            )
+            added = True
+
+            if self._baseline is None:
+                aggregates = self._storage.get_all()
+                if len(aggregates) >= BASELINE_DAYS:
+                    base = aggregates[:BASELINE_DAYS]
+                    self._baseline = RefrigerantBaseline(
+                        superheat=median(a.superheat for a in base),
+                        evaporation_temp=median(a.evaporation_temp for a in base),
+                        exv=median(a.exv for a in base),
+                        outdoor_temp=median(a.outdoor_temp for a in base),
+                        days=BASELINE_DAYS,
+                    )
+
+            if self._evaluate().status == STATUS_ALERT:
+                self._alert_streak += 1
+            else:
+                self._alert_streak = 0
+
+        self._reset_day_buffers()
+        return added
+
+    def _evaluate(self) -> RefrigerantStatus:
+        """Classify the circuit from the frozen baseline and the recent window."""
+        aggregates = self._storage.get_all()
+        valid_days = len(aggregates)
+        today_samples = len(self._superheats)
+
+        if self._baseline is None:
+            return RefrigerantStatus(
+                status=STATUS_LEARNING,
+                superheat_delta=None,
+                exv_delta=None,
+                evaporation_temp_delta=None,
+                baseline=None,
+                valid_days=valid_days,
+                today_samples=today_samples,
+                alert_streak=self._alert_streak,
+            )
+
+        recent = aggregates[-EVAL_DAYS:]
+        if len(recent) < MIN_EVAL_DAYS:
+            return RefrigerantStatus(
+                status=STATUS_OK,
+                superheat_delta=None,
+                exv_delta=None,
+                evaporation_temp_delta=None,
+                baseline=self._baseline,
+                valid_days=valid_days,
+                today_samples=today_samples,
+                alert_streak=self._alert_streak,
+            )
+
+        delta_superheat = median(a.superheat for a in recent) - self._baseline.superheat
+        delta_evap = (
+            median(a.evaporation_temp for a in recent) - self._baseline.evaporation_temp
+        )
+
+        # EVO is compared like-for-like on outdoor temperature.
+        matched = [
+            a
+            for a in recent
+            if abs(a.outdoor_temp - self._baseline.outdoor_temp) <= TEMP_MATCH_K
+        ]
+        delta_exv: float | None = None
+        if len(matched) >= MIN_EVAL_DAYS:
+            delta_exv = median(a.exv for a in matched) - self._baseline.exv
+
+        if (
+            delta_superheat >= SUPERHEAT_ALERT_K
+            and delta_exv is not None
+            and delta_exv >= EVO_ALERT_PCT
+        ):
+            status = STATUS_ALERT
+        elif delta_superheat >= SUPERHEAT_WATCH_K:
+            status = STATUS_WATCH
+        else:
+            status = STATUS_OK
+
+        return RefrigerantStatus(
+            status=status,
+            superheat_delta=round(delta_superheat, 2),
+            exv_delta=None if delta_exv is None else round(delta_exv, 2),
+            evaporation_temp_delta=round(delta_evap, 2),
+            baseline=self._baseline,
+            valid_days=valid_days,
+            today_samples=today_samples,
+            alert_streak=self._alert_streak,
+        )
+
+    def _should_sample(self, data: RefrigerantInput) -> bool:
+        """Return whether the current poll qualifies for sampling."""
+        if not data.data_reliable:
+            return False
+        if data.operation_mode != MODE_HEATING:
+            return False
+        frequency = data.compressor_frequency
+        if frequency is None or not (MIN_FREQUENCY <= frequency <= MAX_FREQUENCY):
+            return False
+        return not (
+            data.gas_temp is None
+            or data.evaporator_temp is None
+            or data.outdoor_expansion_valve is None
+            or data.outdoor_temp is None
+        )
+
+    def _reset_day_buffers(self) -> None:
+        """Clear the transient intra-day sample buffers."""
+        self._superheats = []
+        self._evos = []
+        self._evaps = []
+        self._outdoors = []
+
+    def preload_aggregates(self, aggregates: Iterable[DailyAggregate]) -> None:
+        """Load historical daily aggregates (used by tests / rehydration)."""
+        for aggregate in aggregates:
+            self._storage.append(aggregate)

--- a/custom_components/hitachi_yutaki/entities/compressor/__init__.py
+++ b/custom_components/hitachi_yutaki/entities/compressor/__init__.py
@@ -1,9 +1,12 @@
 """Compressor domain entities."""
 
 from .binary_sensors import build_compressor_binary_sensors
-from .sensors import build_compressor_sensors
+from .buttons import build_refrigerant_buttons
+from .sensors import build_compressor_sensors, build_refrigerant_sensors
 
 __all__ = [
     "build_compressor_sensors",
     "build_compressor_binary_sensors",
+    "build_refrigerant_sensors",
+    "build_refrigerant_buttons",
 ]

--- a/custom_components/hitachi_yutaki/entities/compressor/buttons.py
+++ b/custom_components/hitachi_yutaki/entities/compressor/buttons.py
@@ -1,0 +1,50 @@
+"""Compressor button descriptions and builders."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.const import EntityCategory
+
+from ...const import DEVICE_PRIMARY_COMPRESSOR
+from ..base.button import (
+    HitachiYutakiButton,
+    HitachiYutakiButtonEntityDescription,
+    _create_buttons,
+)
+
+if TYPE_CHECKING:
+    from ...coordinator import HitachiYutakiDataCoordinator
+
+
+def build_refrigerant_buttons(
+    coordinator: HitachiYutakiDataCoordinator,
+    entry_id: str,
+) -> list[HitachiYutakiButton]:
+    """Build the refrigerant detector reset button."""
+    descriptions = _build_refrigerant_button_descriptions()
+    return _create_buttons(
+        coordinator, entry_id, descriptions, DEVICE_PRIMARY_COMPRESSOR
+    )
+
+
+def _build_refrigerant_button_descriptions() -> tuple[
+    HitachiYutakiButtonEntityDescription, ...
+]:
+    """Build refrigerant detector button descriptions."""
+    return (
+        HitachiYutakiButtonEntityDescription(
+            key="reset_refrigerant_baseline",
+            translation_key="reset_refrigerant_baseline",
+            icon="mdi:restart",
+            entity_category=EntityCategory.CONFIG,
+            description=(
+                "Reset the refrigerant-charge detection baseline. Use after a "
+                "refrigerant top-up or expansion-valve service so a new reference "
+                "is learned from scratch."
+            ),
+            action_fn=lambda coordinator: (
+                coordinator.async_reset_refrigerant_baseline()
+            ),
+        ),
+    )

--- a/custom_components/hitachi_yutaki/entities/compressor/sensors.py
+++ b/custom_components/hitachi_yutaki/entities/compressor/sensors.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from custom_components.hitachi_yutaki.const import DEVICE_TYPES
+from custom_components.hitachi_yutaki.const import (
+    DEVICE_PRIMARY_COMPRESSOR,
+    DEVICE_TYPES,
+)
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import (
     PERCENTAGE,
@@ -15,6 +18,12 @@ from homeassistant.const import (
 )
 from homeassistant.helpers.entity import EntityCategory
 
+from ...domain.services.refrigerant import (
+    STATUS_ALERT,
+    STATUS_LEARNING,
+    STATUS_OK,
+    STATUS_WATCH,
+)
 from ..base.sensor import (
     HitachiYutakiSensor,
     HitachiYutakiSensorEntityDescription,
@@ -294,3 +303,56 @@ def _build_compressor_sensor_descriptions(
                 value_fn=lambda c: c.data.get("secondary_compressor_resttime"),
             ),
         )
+
+
+def build_refrigerant_sensors(
+    coordinator: HitachiYutakiDataCoordinator,
+    entry_id: str,
+) -> list[HitachiYutakiSensor]:
+    """Build the refrigerant-circuit anomaly diagnostic sensor."""
+    descriptions = _build_refrigerant_sensor_descriptions()
+    return _create_sensors(
+        coordinator, entry_id, descriptions, DEVICE_PRIMARY_COMPRESSOR
+    )
+
+
+def _refrigerant_attributes(
+    coordinator: HitachiYutakiDataCoordinator,
+) -> dict[str, object] | None:
+    """Expose the detector's deltas and warm-up progress as attributes."""
+    if coordinator.data is None:
+        return None
+    return {
+        "superheat_delta": coordinator.data.get("refrigerant_charge_superheat_delta"),
+        "exv_delta": coordinator.data.get("refrigerant_charge_exv_delta"),
+        "evaporation_temp_delta": coordinator.data.get(
+            "refrigerant_charge_evaporation_temp_delta"
+        ),
+        "baseline_days": coordinator.data.get("refrigerant_charge_baseline_days"),
+        "valid_days": coordinator.data.get("refrigerant_charge_valid_days"),
+        "alert_streak": coordinator.data.get("refrigerant_charge_alert_streak"),
+    }
+
+
+def _build_refrigerant_sensor_descriptions() -> tuple[
+    HitachiYutakiSensorEntityDescription, ...
+]:
+    """Build refrigerant-circuit anomaly sensor descriptions."""
+    return (
+        HitachiYutakiSensorEntityDescription(
+            key="refrigerant_charge_status",
+            translation_key="refrigerant_charge_status",
+            description=(
+                "Continuous refrigerant-charge anomaly detection (superheat and "
+                "expansion-valve drift). Advisory only — complements the mandatory "
+                "leak-tightness inspection."
+            ),
+            device_class=SensorDeviceClass.ENUM,
+            options=[STATUS_LEARNING, STATUS_OK, STATUS_WATCH, STATUS_ALERT],
+            entity_category=EntityCategory.DIAGNOSTIC,
+            icon="mdi:gauge-low",
+            condition=lambda c: c.profile.supports_extended_compressor_sensors,
+            value_fn=lambda c: c.data.get("refrigerant_charge_status"),
+            attributes_fn=_refrigerant_attributes,
+        ),
+    )

--- a/custom_components/hitachi_yutaki/manifest.json
+++ b/custom_components/hitachi_yutaki/manifest.json
@@ -15,5 +15,5 @@
   "requirements": [
     "pymodbus>=3.6.9,<4.0.0"
   ],
-  "version": "2.2.0-beta.1"
+  "version": "2.2.0-beta.2"
 }

--- a/custom_components/hitachi_yutaki/sensor.py
+++ b/custom_components/hitachi_yutaki/sensor.py
@@ -18,7 +18,7 @@ from .const import (
 
 # Import builders from domain entities
 from .entities.circuit import build_circuit_sensors
-from .entities.compressor import build_compressor_sensors
+from .entities.compressor import build_compressor_sensors, build_refrigerant_sensors
 from .entities.control_unit import build_control_unit_sensors
 from .entities.dhw import build_dhw_sensors
 from .entities.gateway import build_gateway_sensors
@@ -97,6 +97,9 @@ async def async_setup_entry(
             device_type=DEVICE_SECONDARY_COMPRESSOR,
         )
     )
+
+    # Refrigerant-circuit anomaly diagnostic (gated on extended compressor sensors)
+    entities.extend(build_refrigerant_sensors(coordinator, entry.entry_id))
 
     # Performance sensors (COP)
     entities.extend(build_performance_sensors(coordinator, entry.entry_id))

--- a/custom_components/hitachi_yutaki/translations/en.json
+++ b/custom_components/hitachi_yutaki/translations/en.json
@@ -530,6 +530,15 @@
           "on": "On"
         }
       },
+      "refrigerant_charge_status": {
+        "name": "Refrigerant Charge Status",
+        "state": {
+          "learning": "Learning",
+          "ok": "OK",
+          "watch": "Watch",
+          "alert": "Alert"
+        }
+      },
       "dhw_demand_mode": {
         "name": "DHW Demand Mode",
         "state": {
@@ -639,6 +648,9 @@
     "button": {
       "antilegionella": {
         "name": "Start Anti-legionella Cycle"
+      },
+      "reset_refrigerant_baseline": {
+        "name": "Reset Refrigerant Baseline"
       }
     },
     "number": {
@@ -725,6 +737,10 @@
     "connection_error": {
       "title": "Hitachi Gateway Unreachable",
       "description": "The integration could not connect to the Hitachi Yutaki gateway. The entities will be unavailable until the connection is restored.\n\n**To resolve this:**\n1. Check if the gateway is powered on and connected to the network.\n2. Verify that the IP address and port configured in Home Assistant are correct."
+    },
+    "refrigerant_charge_alert": {
+      "title": "Possible Refrigerant Charge Loss",
+      "description": "For several days the Refrigerant Charge Status has stayed at **Alert**: suction superheat and the expansion-valve opening have both drifted up from the learned baseline, the classic signature of a slow refrigerant loss.\n\nThis is an **advisory** based on continuous monitoring of your own operating data. It **complements** and does **not** replace the mandatory periodic leak-tightness inspection by a certified technician.\n\n**What to do:**\n1. Watch the Refrigerant Charge Status sensor and its attributes over the next days.\n2. Consider scheduling a leak-tightness check with your installer.\n3. After any refrigerant top-up or expansion-valve service, press **Reset Refrigerant Baseline** so a new reference is learned.\n\nThe warning clears automatically when the readings return to normal."
     },
     "initializing_warning": {
       "title": "Hitachi Gateway Initializing",

--- a/custom_components/hitachi_yutaki/translations/fr.json
+++ b/custom_components/hitachi_yutaki/translations/fr.json
@@ -530,6 +530,15 @@
           "on": "Activée"
         }
       },
+      "refrigerant_charge_status": {
+        "name": "État de la charge frigorigène",
+        "state": {
+          "learning": "Apprentissage",
+          "ok": "Normal",
+          "watch": "Surveillance",
+          "alert": "Alerte"
+        }
+      },
       "dhw_demand_mode": {
         "name": "Mode de demande ECS",
         "state": {
@@ -639,6 +648,9 @@
     "button": {
       "antilegionella": {
         "name": "Démarrer le cycle anti-légionelle"
+      },
+      "reset_refrigerant_baseline": {
+        "name": "Réinitialiser la référence frigorigène"
       }
     },
     "number": {
@@ -725,6 +737,10 @@
     "connection_error": {
       "title": "Passerelle Hitachi Inaccessible",
       "description": "L'intégration n'a pas pu se connecter à la passerelle Hitachi Yutaki. Les entités seront indisponibles jusqu'à ce que la connexion soit rétablie.\n\n**Pour résoudre ce problème :**\n1. Vérifiez si la passerelle est sous tension et connectée au réseau.\n2. Vérifiez que l'adresse IP et le port configurés dans Home Assistant sont corrects."
+    },
+    "refrigerant_charge_alert": {
+      "title": "Perte possible de charge frigorigène",
+      "description": "Depuis plusieurs jours, l'état de la charge frigorigène reste en **Alerte** : la surchauffe à l'aspiration et l'ouverture du détendeur ont toutes deux dérivé à la hausse par rapport à la référence apprise, la signature classique d'une fuite lente de frigorigène.\n\nIl s'agit d'un **avertissement** basé sur la surveillance continue de vos propres données de fonctionnement. Il **complète** et ne **remplace pas** le contrôle d'étanchéité périodique obligatoire par un technicien certifié.\n\n**Que faire :**\n1. Surveillez le capteur d'état de la charge frigorigène et ses attributs les jours suivants.\n2. Envisagez de programmer un contrôle d'étanchéité avec votre installateur.\n3. Après toute recharge de frigorigène ou intervention sur le détendeur, appuyez sur **Réinitialiser la référence frigorigène** pour réapprendre une référence.\n\nL'avertissement disparaît automatiquement lorsque les mesures reviennent à la normale."
     },
     "initializing_warning": {
       "title": "Passerelle Hitachi en cours d'initialisation",

--- a/custom_components/hitachi_yutaki/translations/nl.json
+++ b/custom_components/hitachi_yutaki/translations/nl.json
@@ -530,6 +530,15 @@
           "on": "Aan"
         }
       },
+      "refrigerant_charge_status": {
+        "name": "Status koudemiddelvulling",
+        "state": {
+          "learning": "Leren",
+          "ok": "OK",
+          "watch": "Waakzaam",
+          "alert": "Alarm"
+        }
+      },
       "dhw_demand_mode": {
         "name": "SWW Vraagmodus",
         "state": {
@@ -639,6 +648,9 @@
     "button": {
       "antilegionella": {
         "name": "Anti-legionellacyclus starten"
+      },
+      "reset_refrigerant_baseline": {
+        "name": "Koudemiddel-referentie resetten"
       }
     },
     "number": {
@@ -725,6 +737,10 @@
     "connection_error": {
       "title": "Hitachi Gateway onbereikbaar",
       "description": "De integratie kon geen verbinding maken met de Hitachi Yutaki gateway. De entiteiten zijn niet beschikbaar totdat de verbinding is hersteld.\n\n**Om dit op te lossen:**\n1. Controleer of de gateway is ingeschakeld en verbonden met het netwerk.\n2. Controleer of het IP-adres en de poort in Home Assistant correct zijn geconfigureerd."
+    },
+    "refrigerant_charge_alert": {
+      "title": "Mogelijk verlies van koudemiddelvulling",
+      "description": "Al enkele dagen blijft de status van de koudemiddelvulling op **Alarm** staan: zowel de oververhitting bij aanzuiging als de opening van het expansieventiel zijn ten opzichte van de aangeleerde referentie gestegen, de klassieke signatuur van een langzaam koudemiddelverlies.\n\nDit is een **waarschuwing** op basis van continue monitoring van uw eigen bedrijfsgegevens. Het **vult** de verplichte periodieke lekdichtheidsinspectie door een gecertificeerd technicus **aan** en **vervangt** deze **niet**.\n\n**Wat te doen:**\n1. Volg de sensor voor de status van de koudemiddelvulling en de bijbehorende attributen de komende dagen.\n2. Overweeg een lekdichtheidscontrole in te plannen met uw installateur.\n3. Druk na het bijvullen van koudemiddel of onderhoud aan het expansieventiel op **Koudemiddel-referentie resetten** zodat een nieuwe referentie wordt aangeleerd.\n\nDe waarschuwing verdwijnt automatisch wanneer de metingen weer normaal zijn."
     },
     "initializing_warning": {
       "title": "Hitachi Gateway wordt geïnitialiseerd",

--- a/custom_components/hitachi_yutaki/translations/ro.json
+++ b/custom_components/hitachi_yutaki/translations/ro.json
@@ -530,6 +530,15 @@
           "on": "Activat"
         }
       },
+      "refrigerant_charge_status": {
+        "name": "Stare încărcare agent frigorific",
+        "state": {
+          "learning": "Învățare",
+          "ok": "OK",
+          "watch": "Supraveghere",
+          "alert": "Alertă"
+        }
+      },
       "dhw_demand_mode": {
         "name": "Mod cerere ACM",
         "state": {
@@ -639,6 +648,9 @@
     "button": {
       "antilegionella": {
         "name": "Pornire ciclu anti-legionella"
+      },
+      "reset_refrigerant_baseline": {
+        "name": "Resetare referință agent frigorific"
       }
     },
     "number": {
@@ -725,6 +737,10 @@
     "connection_error": {
       "title": "Gateway Hitachi inaccesibil",
       "description": "Integrarea nu s-a putut conecta la gateway-ul Hitachi Yutaki. Entitățile nu vor fi disponibile până la restabilirea conexiunii.\n\n**Pentru a rezolva:**\n1. Verificați dacă gateway-ul este pornit și conectat la rețea.\n2. Verificați dacă adresa IP și portul configurate în Home Assistant sunt corecte."
+    },
+    "refrigerant_charge_alert": {
+      "title": "Posibilă pierdere a agentului frigorific",
+      "description": "De câteva zile, starea încărcării cu agent frigorific rămâne la **Alertă**: atât supraîncălzirea la aspirație, cât și deschiderea ventilului de expansiune au crescut față de referința învățată, semnătura clasică a unei pierderi lente de agent frigorific.\n\nAceasta este o **avertizare** bazată pe monitorizarea continuă a propriilor date de funcționare. Ea **completează** și **nu înlocuiește** inspecția periodică obligatorie de etanșeitate efectuată de un tehnician autorizat.\n\n**Ce trebuie făcut:**\n1. Urmăriți în zilele următoare senzorul de stare a încărcării cu agent frigorific și atributele sale.\n2. Luați în considerare programarea unei verificări de etanșeitate cu instalatorul dumneavoastră.\n3. După orice completare de agent frigorific sau intervenție la ventilul de expansiune, apăsați **Resetare referință agent frigorific** pentru a învăța o nouă referință.\n\nAvertizarea dispare automat când valorile revin la normal."
     },
     "initializing_warning": {
       "title": "Gateway Hitachi în curs de inițializare",

--- a/docs/reference/domain-services.md
+++ b/docs/reference/domain-services.md
@@ -161,6 +161,52 @@ Historical states can be preloaded from the Recorder for continuity across resta
 
 ---
 
+## Refrigerant Anomaly Detection
+
+**File:** `domain/services/refrigerant.py`
+
+Continuously detects the early signature of a **slow refrigerant charge loss**. Advisory
+only — complements, does not replace, the mandatory F-Gas leak-tightness inspection. Full
+rationale and user-facing behaviour: [Refrigerant monitoring](refrigerant-monitoring.md).
+
+### Key class
+
+| Class | Role |
+|---|---|
+| `RefrigerantMonitor` | Gates and reduces per-poll signals into one robust daily aggregate, freezes a baseline, and classifies drift against it. |
+
+### Signals and superheat
+
+Suction superheat `SH = Tg − Te` (`compressor_tg_gas_temp` −
+`compressor_te_evaporator_temp`), outdoor expansion-valve opening `EVO`, evaporating
+temperature `Te` and outdoor temperature. Gated on `supports_extended_compressor_sensors`
+(needs `Tg`/`EVO`; excludes the Yutampo R32).
+
+### States
+
+| Level | Condition |
+|---|---|
+| `learning` | Fewer than `BASELINE_DAYS` (14) valid days — baseline not frozen |
+| `ok` | Baseline frozen, no significant drift |
+| `watch` | Superheat drift ≥ `SUPERHEAT_WATCH_K` from baseline |
+| `alert` | Superheat ≥ `SUPERHEAT_ALERT_K` **and** temperature-matched EVO ≥ `EVO_ALERT_PCT` |
+
+### Design notes
+
+- **Daily aggregation:** samples (gated on heating mode, defrost-guard reliability, a steady
+  frequency band, plausibility and a 60 s throttle) are reduced to one median-per-day
+  `DailyAggregate`, held in an injected `Storage[DailyAggregate]` bounded to `HISTORY_DAYS`.
+- **Seasonality:** superheat is a *regulated* quantity (robust to weather) and is the
+  primary signal; `EVO` is compared only across days within `TEMP_MATCH_K` of the baseline
+  outdoor temperature; `Te` is informational.
+- **Persistence:** `serialize()`/`restore()` round-trip the baseline, aggregates and alert
+  streak; the adapter persists them via a Home Assistant `Store`. `reset()` clears
+  everything (exposed as the reset button).
+- **Time:** like COP, uses `time()` for the throttle and accepts an optional `timestamp` for
+  replay/tests.
+
+---
+
 ## Electrical Power
 
 **File:** `domain/services/electrical.py`

--- a/docs/reference/entities.md
+++ b/docs/reference/entities.md
@@ -111,6 +111,8 @@ Each COP sensor exposes additional attributes: `quality`, `measurements`, and
 | compressor_cycle_time | sensor | Average time between compressor starts | min | diagnostic |
 | compressor_runtime | sensor | Compressor runtime | min | diagnostic |
 | compressor_resttime | sensor | Compressor rest time | min | diagnostic |
+| refrigerant_charge_status | sensor (ENUM) | Slow-refrigerant-loss detection (learning/ok/watch/alert); advisory, complements the mandatory inspection. Extended-sensor profiles only. See [refrigerant monitoring](refrigerant-monitoring.md) | - | diagnostic |
+| reset_refrigerant_baseline | button | Reset the refrigerant detection baseline after a top-up or expansion-valve service. Extended-sensor profiles only | - | config |
 
 ## Secondary Compressor Device (S80 Model Only)
 

--- a/docs/reference/refrigerant-monitoring.md
+++ b/docs/reference/refrigerant-monitoring.md
@@ -1,0 +1,98 @@
+# Refrigerant-circuit anomaly detection
+
+**Status:** iteration 1 (slow refrigerant loss).
+**Issue:** [#310](https://github.com/alepee/hass-hitachi_yutaki/issues/310).
+
+This feature continuously watches the refrigerant circuit for the early signature of a
+**slow refrigerant charge loss**, using the same physical quantities a technician samples
+during a leak-tightness inspection, but sampled on every poll of your own installation.
+
+> **It is advisory only.** It **complements** and does **not** replace the mandatory,
+> periodic F-Gas leak-tightness inspection by a certified technician.
+
+## What it surfaces
+
+| Entity | Type | Notes |
+|---|---|---|
+| `sensor.*_refrigerant_charge_status` | ENUM diagnostic | `learning` / `ok` / `watch` / `alert`, on the Primary Compressor device |
+| `button.*_reset_refrigerant_baseline` | button (config) | resets the learned baseline after a service/top-up |
+| repair issue `refrigerant_charge_alert_*` | self-clearing warning | raised when `alert` persists several days |
+
+The sensor exposes attributes: `superheat_delta` (K), `exv_delta` (%, `null` when it cannot
+be compared at equivalent outdoor temperature), `evaporation_temp_delta` (K, informational),
+`baseline_days`, `valid_days`, `alert_streak`.
+
+Only profiles with `supports_extended_compressor_sensors` (i.e. all except the Yutampo R32)
+expose these, because the detector needs the gas temperature `Tg` and the outdoor expansion
+valve `EVO`, which the compact Yutampo R32 does not report.
+
+## How it works
+
+The detector lives in the domain layer (`domain/services/refrigerant.py`, class
+`RefrigerantMonitor`) and is driven by the coordinator adapter on each poll.
+
+### Signals
+
+- **Suction superheat** `SH = Tg − Te` (`compressor_tg_gas_temp` −
+  `compressor_te_evaporator_temp`).
+- **Outdoor expansion-valve opening** `EVO`
+  (`compressor_evo_outdoor_expansion_valve_opening`, 0–100 %).
+- **Evaporating temperature** `Te` and **outdoor temperature** for context.
+
+### Sampling gate
+
+A sample is recorded only when the poll is trustworthy and comparable: **heating mode**
+(the outdoor coil is the evaporator, so `EVO` is the regulating valve), data reliable (the
+defrost guard is not filtering), compressor frequency in a steady band, all signals present
+and plausible, and at most one sample per minute. DHW and pool cycles are excluded by
+construction (distinct operation modes).
+
+### Baseline and detection
+
+Samples are reduced to one robust **daily aggregate** (medians). After 14 valid days a
+**baseline is frozen**. The last few valid days form a **recent window** compared to the
+baseline:
+
+- **Superheat** is the primary signal. It is a *regulated* quantity: a healthy circuit
+  holds it in a stable band regardless of the weather, so a sustained rise is meaningful.
+- **EVO** corroborates, but only over recent days whose outdoor temperature is within a few
+  kelvin of the baseline's — because valve position genuinely moves with outdoor
+  temperature, comparing unlike conditions would be misleading.
+- **Te** is reported for information only; it is too weather-dependent to gate on.
+
+| Status | Meaning |
+|---|---|
+| `learning` | Not enough history yet (warm-up). |
+| `ok` | Baseline established, no significant drift. |
+| `watch` | Superheat has drifted up from the baseline. |
+| `alert` | Superheat **and** temperature-matched EVO opening have both drifted up — the classic slow-leak signature. |
+
+When `alert` persists for several days a self-clearing repair issue is raised. It disappears
+automatically when readings recover.
+
+### Persistence and reset
+
+The baseline and daily aggregates are persisted (Home Assistant `Store`) so they survive
+restarts and build up over weeks, independent of whether the diagnostic entity is enabled.
+After a **legitimate refrigerant top-up or expansion-valve service**, press **Reset
+Refrigerant Baseline** so a fresh reference is learned; otherwise the stale baseline would
+keep alerting.
+
+## Limitations (expected)
+
+- **Warm-up:** needs ~2–3 weeks of heating operation before it can leave `learning`. Off
+  season it stays `learning`.
+- **Heating only** in this iteration; cooling-dominant installs won't accumulate data.
+- **Heuristic thresholds:** false positives are possible on unusual load patterns. The
+  superheat-primary rule, the temperature-matched EVO check and daily medians mitigate this,
+  but the result is an early-warning hint, not a measurement of charge.
+- **Coarse superheat:** temperatures are whole-degree integers, so superheat has ~1 K
+  quantization; daily medians recover finer resolution.
+- **Not available on the Yutampo R32** (no `Tg`/`EVO`).
+
+## Tuning constants
+
+All thresholds live at the top of `domain/services/refrigerant.py`
+(`BASELINE_DAYS`, `EVAL_DAYS`, `MIN_SAMPLES_PER_DAY`, `SUPERHEAT_WATCH_K`,
+`SUPERHEAT_ALERT_K`, `EVO_ALERT_PCT`, `TEMP_MATCH_K`, `ALERT_PERSIST_DAYS`, …) and are
+covered by `tests/domain/services/test_refrigerant.py`.

--- a/docs/superpowers/specs/2026-07-22-refrigerant-anomaly-detection-design.md
+++ b/docs/superpowers/specs/2026-07-22-refrigerant-anomaly-detection-design.md
@@ -1,0 +1,277 @@
+# Design: refrigerant-circuit anomaly detection (iteration 1)
+
+**Issue:** [#310](https://github.com/alepee/hass-hitachi_yutaki/issues/310)
+**Date:** 2026-07-22
+**Scope:** first iteration — one local detector for *slow refrigerant loss*, a diagnostic
+entity, a self-clearing repair issue, tests and docs.
+
+---
+
+## 1. Goal and non-goals
+
+Surface early signs of a **slow refrigerant charge loss** between two mandatory F-Gas
+leak-tightness inspections, using signals the integration already reads every poll. This
+**complements** and does **not** replace the legal inspection.
+
+**In scope (this PR):**
+
+- One domain detector for slow refrigerant loss, running locally on rolling history.
+- A diagnostic ENUM sensor `sensor.*_refrigerant_charge_status` with states
+  `learning` / `ok` / `watch` / `alert` plus explanatory attributes.
+- A self-clearing repair issue raised when `alert` persists over several days, with
+  language making clear it complements the mandatory inspection.
+- Unit tests (pure domain) and a documentation page.
+
+**Out of scope (future iterations, tracked on #310):**
+
+- EXV-hunting and heat-exchanger-fouling detectors, compressor-degradation detector.
+- Fleet/telemetry-bootstrapped baselines (issue's "could help" section). Iteration 1 is
+  strictly **local baselines**, as the issue recommends.
+- Any actuation (compressor protection, shutdown). Strictly read-only / advisory.
+- Quantitative refrigerant-charge estimation.
+- Cooling-mode detection (heating only in iteration 1 — see §4).
+
+---
+
+## 2. Physical basis (why these signals)
+
+A slow undercharge/leak has a classic thermodynamic signature at the evaporator:
+
+- **Suction superheat rises.** Superheat `SH = Tg − Te` where `Tg` =
+  `compressor_tg_gas_temp` (suction gas temperature) and `Te` =
+  `compressor_te_evaporator_temp` (evaporating/saturation temperature). Less refrigerant →
+  the evaporator dries out earlier → suction gas is hotter above saturation.
+- **The expansion valve opens further to compensate.** `EVO` =
+  `compressor_evo_outdoor_expansion_valve_opening` trends up as the EXV tries to restore
+  superheat, until it saturates.
+- **Evaporating temperature drifts down** (`Te` falls) at equivalent load.
+
+Tracking **superheat and EXV opening is robust to seasonality** because superheat is a
+*regulated* quantity: in a healthy circuit the EXV holds it in a stable band regardless of
+outdoor temperature. A sustained joint drift (SH up **and** EVO up, Te not rising) is the
+discriminating signal.
+
+**Signal availability.** `Tg`, `EVI`, `EVO` are gated by the profile capability
+`supports_extended_compressor_sensors` (only `YutampoR32Profile` sets it `False`). `Te`,
+`Td`, frequency and current are always present. The detector therefore gates on
+`supports_extended_compressor_sensors` — excluding the Yutampo R32, which lacks `Tg`/`EVO`.
+
+---
+
+## 3. Architecture (fits existing hexagonal layers)
+
+```
+Modbus data ──► DerivedMetricsAdapter.update(data)           [adapters/]
+                   └─ RefrigerantMonitor.update(RefrigerantInput, timestamp)
+                        │  (pure domain, no HA imports)       [domain/services/]
+                        ▼
+                   data["refrigerant_charge_status"] + attribute keys
+                        ▼
+   HitachiYutakiRefrigerantSensor  (ENUM, RestoreEntity)      [entities/compressor/]
+        └─ persists/restores detector state via extra-data
+   repairs / __init__: raise/clear repair issue on sustained alert
+```
+
+- **Domain stays pure** (stdlib only, `datetime`/`time`, no HA). Follows the COP pattern:
+  optional `timestamp` kwarg for replay/tests, `time()` for the sample-interval throttle.
+- Rolling history uses the existing `Storage[T]` port + `InMemoryStorage`, holding one
+  compact `DailyAggregate` **per day** (not raw samples), so weeks of history cost ~45
+  records. Intra-day samples live in a transient in-memory buffer.
+- Wiring mirrors COP: instantiated in `DerivedMetricsAdapter.__init__`, driven by a new
+  `_update_refrigerant(data)` inside `update()`, results written into the `data` dict.
+
+### Persistence
+
+Multi-week baselines cannot rely on Recorder replay (default purge ~10 days), nor on the
+sensor's `RestoreEntity` state: a compound state (frozen baseline + up to ~45 daily
+aggregates + alert streak) does not fit a single numeric `last_state`, and an entity that is
+disabled in the registry never fires `async_added_to_hass`, so entity extra-data would be a
+silent no-op. Instead the **adapter owns a `homeassistant.helpers.storage.Store`** (key
+`hitachi_yutaki_refrigerant_{entry_id}`, versioned) holding the serialized detector state,
+fully decoupled from entity enablement:
+
+- Loaded once in `__init__.py async_setup_entry` (alongside the existing thermal/COP
+  restores) and pushed into the service via `restore_refrigerant(state)`.
+- Saved with `store.async_delay_save(monitor.serialize, ...)` on each daily flush (rare, so
+  debounced I/O is negligible) and flushed on `async_unload_entry`.
+
+The transient intra-day buffer is volatile (acceptable: at most the current partial day is
+lost on restart). `Store` is standard HA infrastructure; the repo does not use it yet, but
+it is the correct mechanism for compound, entity-independent persisted state.
+
+---
+
+## 4. Detector logic
+
+### Sampling gate (a sample is recorded only when all hold)
+
+- Operation mode is **heating** (`resolve_operation_mode(operation_state) == MODE_HEATING`).
+  Heating means the outdoor coil is the evaporator, so `EVO` is the relevant valve.
+- `defrost_guard.is_data_reliable` is `True` (reuses the existing guard; no sampling during
+  defrost/recovery windows).
+- Compressor running with frequency in a steady band `[MIN_FREQUENCY, MAX_FREQUENCY]`
+  (excludes idle and startup/extreme load, keeping load roughly comparable).
+- `Tg`, `Te`, `EVO`, `outdoor_temp` all present (not `None`) and plausible:
+  `-10 ≤ SH ≤ 40 K`, `0 ≤ EVO ≤ 100 %` (datasheet range, confirmed
+  `docs/gateway/atw-mbs-02.md`), `-60 ≤ Te ≤ 40 °C`, `-40 ≤ outdoor_temp ≤ 40 °C`. The
+  plausibility clamp also guards `EVO`'s missing-deserializer `0xFFFF` (= 65535) case.
+- At most one sample per `SAMPLE_MIN_INTERVAL_S` (60 s), throttled like COP.
+
+Each sample records `(superheat = Tg − Te, evo, te, outdoor_temp)` into the day's buffer.
+
+### Daily aggregation
+
+At a date rollover (host local time, matching the thermal daily-energy reset), the previous
+day is flushed: if it has
+`≥ MIN_SAMPLES_PER_DAY` (30) samples it becomes a **valid** `DailyAggregate` holding the
+**median** of superheat, evo, te and outdoor_temp for the day (medians are robust to
+outliers); otherwise the day is discarded. Aggregates are stored in an
+`InMemoryStorage(max_len=HISTORY_DAYS)` (45), oldest pruned first.
+
+### Baseline and evaluation
+
+The **baseline is frozen once**, tracked by an explicit `baseline: RefrigerantBaseline |
+None` field (never re-inferred from the aggregate list, which ages out of the 45-slot
+window). Let `V` be the current valid daily aggregates (chronological).
+
+- Baseline not yet frozen and fewer than `BASELINE_DAYS` (14) valid days accumulated →
+  status `learning`. When the 14th valid day arrives, freeze `baseline` = per-metric median
+  over those first 14 days (superheat, evo, te, **and baseline outdoor_temp**).
+- **Recent window** = the last up-to-`EVAL_DAYS` (7) valid days. Need `≥ MIN_EVAL_DAYS` (3)
+  → otherwise status `ok` (baseline frozen, still accumulating).
+- `dSH` = recent-median superheat − baseline superheat (all recent days; superheat is a
+  *regulated* quantity, so this is seasonally robust).
+- **EVO is compared like-for-like on outdoor temperature.** `dEVO` is computed only over
+  recent days whose median outdoor_temp is within `±TEMP_MATCH_K` (4 K) of the baseline
+  outdoor_temp. If fewer than `MIN_EVAL_DAYS` temp-matched recent days exist, `dEVO` is
+  `None` (corroboration unavailable).
+- `dTe` (recent − baseline) is recorded for the attributes only; it is **not** a gate,
+  because `Te` moves strongly with outdoor temperature (see rationale below).
+
+### Classification (leak signature)
+
+`SH` (regulated → seasonally robust) is the primary signal; `EVO` corroborates only when it
+can be compared at equivalent outdoor temperature. This is deliberately conservative to
+avoid F-Gas-implying false alarms at the first cold spell:
+
+| Status  | Condition |
+|---------|-----------|
+| `alert` | `dSH ≥ SH_ALERT (5 K)` **and** `dEVO` available **and** `dEVO ≥ EVO_ALERT (15 %)` |
+| `watch` | `dSH ≥ SH_WATCH (3 K)` (SH drift alone; EVO not required) |
+| `ok`    | otherwise |
+
+Rationale for demoting `Te` and temp-matching `EVO`: at fixed target superheat and load,
+`EVO` position and `Te` still vary strongly with outdoor temperature; a baseline frozen on
+mild early-season days vs. a colder recent window produces benign `dEVO↑`/`dTe↓` that would
+otherwise mimic a leak. Superheat does not have this bias. Thresholds are heuristic and
+conservative; `Tg`/`Te` are whole-degree integers (`convert_signed_16bit`), so `SH` has ~1 K
+quantization — daily medians recover sub-degree resolution, and the 3 K / 5 K thresholds sit
+comfortably above the noise floor. All documented as such.
+
+### Re-baseline / reset
+
+After a legitimate refrigerant top-up or EXV service the frozen baseline is stale and would
+alert forever. A **reset button** (`button.*_reset_refrigerant_baseline`, on the Primary
+Compressor device) clears the monitor state, deletes the `Store` payload, and removes any
+active repair issue. This is the only supported reset (a config reload alone must *not* wipe
+the baseline, since `Store` persists it deliberately).
+
+### Alert persistence → repair issue
+
+At each daily flush the day's status is evaluated; an `alert_streak` counter increments on
+`alert` and resets otherwise (persisted in the `Store` state). The repair issue is
+raised/cleared from `coordinator._async_update_data` (the established update-driven pattern,
+mirroring the `connection_error` issue), **not** from `__init__.py`: when
+`alert_streak ≥ ALERT_PERSIST_DAYS` (3) raise `refrigerant_charge_alert_{entry_id}`
+(`WARNING`, non-fixable, self-clearing); delete it when the status leaves `alert`. The live
+sensor always reflects the current classification.
+
+---
+
+## 5. Public surfaces
+
+### Domain models (`domain/models/refrigerant.py`)
+
+- `RefrigerantInput` — dataclass: `operation_mode: str | None`, `compressor_frequency:
+  float | None`, `gas_temp`, `evaporator_temp`, `outdoor_expansion_valve`, `outdoor_temp`,
+  `data_reliable: bool`.
+- `DailyAggregate` — NamedTuple: `day: date`, `superheat`, `evaporation_temp`, `exv`,
+  `outdoor_temp`, `sample_count`.
+- `RefrigerantBaseline` — dataclass: `superheat`, `evaporation_temp`, `exv`, `outdoor_temp`,
+  `days`.
+- `RefrigerantStatus` — dataclass: `status: str`, `superheat_delta`, `exv_delta` (`None`
+  when not temp-matched), `evaporation_temp_delta`, `baseline: RefrigerantBaseline | None`,
+  `valid_days`, `today_samples`, `alert_streak`.
+
+### Domain service (`domain/services/refrigerant.py`)
+
+- Tuning constants (module-level, imported by tests).
+- `RefrigerantMonitor(storage: Storage[DailyAggregate])` with:
+  `update(data, *, timestamp=None)`, `get_status() -> RefrigerantStatus`,
+  `serialize() -> dict`, `restore(state: dict)`.
+
+### Adapter (`adapters/derived_metrics.py`)
+
+- Instantiate the monitor in `__init__` (gated on `supports_extended_compressor_sensors`;
+  when unsupported the monitor is `None` and `_update_refrigerant` is a no-op), add
+  `_update_refrigerant(data)` to `update()`, write:
+  `data["refrigerant_charge_status"]` and `_superheat_delta` / `_exv_delta` /
+  `_evaporation_temp_delta` / `_baseline_days` / `_valid_days` / `_alert_streak`.
+- Expose `serialize_refrigerant()` / `restore_refrigerant(state)` passthroughs and a
+  `refrigerant_status` property (the latest `RefrigerantStatus`) for the coordinator repair
+  check and the reset button. Hold the `Store` and trigger `async_delay_save` on flush.
+
+### Entity (`entities/compressor/`)
+
+- `HitachiYutakiRefrigerantSensor(HitachiYutakiSensor)` on the **Primary Compressor**
+  device (`DEVICE_PRIMARY_COMPRESSOR`): `device_class=ENUM`,
+  `options=[learning, ok, watch, alert]`, `entity_category=DIAGNOSTIC`,
+  `entity_registry_enabled_default=True` (headline user-facing feature; persistence lives in
+  the adapter `Store`, so it does not depend on the entity being enabled). State and
+  attributes come from `value_fn` / `attributes_fn` reading `coordinator.data` (no override
+  needed). Built by a new `build_refrigerant_sensors(...)` gated on
+  `supports_extended_compressor_sensors`, called from `sensor.py`.
+- `button.py` + `entities/compressor/buttons.py`: `HitachiYutakiResetRefrigerantBaselineButton`
+  (`EntityCategory.CONFIG`, gated the same way) → calls
+  `coordinator.derived_metrics.reset_refrigerant()` which clears the monitor, deletes the
+  `Store` payload, and removes the repair issue. `button.py` is a new platform file added to
+  `PLATFORMS` in `__init__.py`.
+
+### Repair issue + translations + docs
+
+- Raise/clear `refrigerant_charge_alert_{entry_id}` from `coordinator._async_update_data`
+  (non-fixable, self-clearing). Add `issues.refrigerant_charge_alert`, the
+  `entity.sensor.refrigerant_charge_status` state map, and the
+  `entity.button.reset_refrigerant_baseline` name to `translations/en.json` (+ fr; nl/ro via
+  Weblate). Add a `docs/reference/` page (and link it from the index + doc-sync map) and a
+  `CHANGELOG.md` `[Unreleased]` entry.
+
+---
+
+## 6. Testing
+
+Pure-domain tests in `tests/domain/test_refrigerant.py`, mirroring `test_cop.py` /
+`test_timing.py`: a `_make_input(...)` builder, `InMemoryStorage(max_len=...)`, injected
+`timestamp`s to walk simulated days forward, and `monkeypatch` of the module `time` for the
+interval throttle. Cases: sampling gate (mode/reliability/frequency/None/plausibility),
+daily flush + `MIN_SAMPLES_PER_DAY`, `learning → ok` after warm-up, `watch` on SH-only
+drift, `alert` on a synthetic leak drift with temp-matched EVO, **no false alert on a
+cold-weather shift** (EVO/Te move but SH stable, and EVO not temp-matched), `dEVO=None` when
+no temp-matched recent days, alert-streak increment/reset, serialize/restore round-trip, and
+reset clearing the baseline.
+
+---
+
+## 7. Risks and limits (documented for users)
+
+- Needs several weeks of heating operation before it can fire (warm-up: 14 valid baseline
+  days + 3 recent). Off-season it stays `learning`.
+- Heating-mode only in iteration 1; cooling-dominant installs won't accumulate data. DHW/pool
+  cycles are excluded by construction (distinct operation modes).
+- Heuristic thresholds → false positives possible on unusual load patterns; the SH-primary +
+  temp-matched-EVO rule and daily medians mitigate this. The repair text states it is
+  advisory and complements the mandatory inspection.
+- After a refrigerant top-up or EXV service the baseline is stale until reset via the reset
+  button; documented in the repair text and the reference page.
+- Excludes Yutampo R32 (no `Tg`/`EVO`).
+- `SH` has ~1 K quantization (integer-degree registers); mitigated by daily medians.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hass-hitachi-yutaki"
-version = "2.2.0-beta.1"
+version = "2.2.0-beta.2"
 requires-python = ">=3.13.2"
 description = "Home Assistant custom integration for Hitachi Yutaki heat pumps"
 license = "MIT"

--- a/tests/domain/services/test_refrigerant.py
+++ b/tests/domain/services/test_refrigerant.py
@@ -1,0 +1,408 @@
+"""Unit tests for the refrigerant-circuit anomaly detection service."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+import itertools
+
+import pytest
+
+from custom_components.hitachi_yutaki.adapters.storage.in_memory import InMemoryStorage
+from custom_components.hitachi_yutaki.domain.models.refrigerant import RefrigerantInput
+from custom_components.hitachi_yutaki.domain.services import refrigerant as refr
+from custom_components.hitachi_yutaki.domain.services.refrigerant import (
+    BASELINE_DAYS,
+    HISTORY_DAYS,
+    MIN_SAMPLES_PER_DAY,
+    STATUS_ALERT,
+    STATUS_LEARNING,
+    STATUS_OK,
+    STATUS_WATCH,
+    RefrigerantMonitor,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fake_time(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Advance the throttle clock by one interval on every call.
+
+    The service records at most one sample per SAMPLE_MIN_INTERVAL_S. Returning a
+    value one interval later on each call lets tests feed many samples per day.
+    """
+    counter = itertools.count(
+        start=refr.SAMPLE_MIN_INTERVAL_S, step=refr.SAMPLE_MIN_INTERVAL_S
+    )
+    monkeypatch.setattr(refr, "time", lambda: float(next(counter)))
+
+
+def _make_input(
+    *,
+    mode: str | None = "heating",
+    freq: float | None = 50.0,
+    sh: float = 5.0,
+    te: float | None = -5.0,
+    evo: float = 40.0,
+    outdoor: float = 7.0,
+    reliable: bool = True,
+) -> RefrigerantInput:
+    """Build a RefrigerantInput producing a given superheat (Tg - Te = sh)."""
+    return RefrigerantInput(
+        operation_mode=mode,
+        compressor_frequency=freq,
+        gas_temp=None if te is None else te + sh,
+        evaporator_temp=te,
+        outdoor_expansion_valve=evo,
+        outdoor_temp=outdoor,
+        data_reliable=reliable,
+    )
+
+
+def _new_monitor() -> RefrigerantMonitor:
+    """Return a fresh monitor backed by a bounded in-memory storage."""
+    return RefrigerantMonitor(InMemoryStorage(max_len=HISTORY_DAYS))
+
+
+def _feed_days(
+    monitor: RefrigerantMonitor,
+    specs: list[dict],
+    *,
+    start: date = date(2026, 1, 1),
+    samples: int = MIN_SAMPLES_PER_DAY,
+) -> None:
+    """Feed one day per spec, then flush the last day.
+
+    Each spec is a dict of signal params (sh, te, evo, outdoor). A day-boundary
+    update flushes the previous day; a trailing off-mode update flushes the last.
+    """
+    for i, spec in enumerate(specs):
+        day = start + timedelta(days=i)
+        ts = datetime(day.year, day.month, day.day, 12, 0, 0)
+        for _ in range(samples):
+            monitor.update(_make_input(**spec), timestamp=ts)
+    flush_day = start + timedelta(days=len(specs))
+    flush_ts = datetime(flush_day.year, flush_day.month, flush_day.day, 0, 0, 0)
+    # off-mode update: no new sample, but triggers the flush of the last real day.
+    monitor.update(_make_input(mode="off"), timestamp=flush_ts)
+
+
+def _baseline_specs(days: int = BASELINE_DAYS) -> list[dict]:
+    """Return `days` identical steady-state day specs for a clean baseline."""
+    return [{"sh": 5.0, "te": -5.0, "evo": 40.0, "outdoor": 7.0} for _ in range(days)]
+
+
+class TestSamplingGate:
+    """A sample is only recorded when every gate condition holds."""
+
+    @pytest.mark.parametrize(
+        "override",
+        [
+            {"mode": "cooling"},
+            {"mode": "dhw"},
+            {"mode": None},
+            {"reliable": False},
+            {"freq": 5.0},  # below MIN_FREQUENCY
+            {"freq": 200.0},  # above MAX_FREQUENCY
+            {"freq": None},
+            {"te": None},  # missing Te -> superheat undefined
+            {"evo": 65535.0},  # 0xFFFF sentinel, out of plausible range
+            {"sh": 100.0},  # implausible superheat
+            {"outdoor": 80.0},  # implausible outdoor temp
+        ],
+    )
+    def test_rejected_samples_do_not_accumulate(self, override: dict) -> None:
+        """Samples failing any gate condition are dropped."""
+        monitor = _new_monitor()
+        ts = datetime(2026, 1, 1, 12, 0, 0)
+        for _ in range(MIN_SAMPLES_PER_DAY):
+            monitor.update(_make_input(**override), timestamp=ts)
+        assert monitor.get_status().today_samples == 0
+
+    def test_valid_samples_accumulate(self) -> None:
+        """Qualifying samples are counted in the current day's buffer."""
+        monitor = _new_monitor()
+        ts = datetime(2026, 1, 1, 12, 0, 0)
+        for _ in range(MIN_SAMPLES_PER_DAY):
+            monitor.update(_make_input(), timestamp=ts)
+        assert monitor.get_status().today_samples == MIN_SAMPLES_PER_DAY
+
+
+class TestDailyAggregation:
+    """Days below the sample threshold are discarded, not aggregated."""
+
+    def test_sparse_day_is_not_valid(self) -> None:
+        """A day with too few samples does not become a valid aggregate."""
+        monitor = _new_monitor()
+        _feed_days(
+            monitor,
+            [{"sh": 5.0, "te": -5.0, "evo": 40.0, "outdoor": 7.0}],
+            samples=MIN_SAMPLES_PER_DAY - 1,
+        )
+        assert monitor.get_status().valid_days == 0
+
+    def test_full_day_becomes_valid(self) -> None:
+        """A day meeting the sample threshold yields one valid aggregate."""
+        monitor = _new_monitor()
+        _feed_days(monitor, _baseline_specs(1))
+        assert monitor.get_status().valid_days == 1
+
+
+class TestBaselineAndClassification:
+    """Warm-up, then verdicts against the frozen baseline."""
+
+    def test_learning_until_baseline(self) -> None:
+        """Before enough baseline days, the status is `learning`."""
+        monitor = _new_monitor()
+        _feed_days(monitor, _baseline_specs(BASELINE_DAYS - 1))
+        status = monitor.get_status()
+        assert status.status == STATUS_LEARNING
+        assert status.baseline is None
+
+    def test_ok_after_baseline_without_drift(self) -> None:
+        """A stable circuit reads `ok` once the baseline is frozen."""
+        monitor = _new_monitor()
+        _feed_days(monitor, _baseline_specs(BASELINE_DAYS))
+        status = monitor.get_status()
+        assert status.baseline is not None
+        assert status.status == STATUS_OK
+
+    def test_watch_on_superheat_only_drift(self) -> None:
+        """Superheat drift alone escalates to `watch`, not `alert`."""
+        monitor = _new_monitor()
+        specs = _baseline_specs(BASELINE_DAYS)
+        # 7 recent days: superheat +4 K, EVO unchanged -> watch, not alert.
+        specs += [
+            {"sh": 9.0, "te": -5.0, "evo": 40.0, "outdoor": 7.0} for _ in range(7)
+        ]
+        _feed_days(monitor, specs)
+        status = monitor.get_status()
+        assert status.status == STATUS_WATCH
+        assert status.superheat_delta == pytest.approx(4.0)
+
+    def test_alert_on_leak_signature(self) -> None:
+        """Joint superheat + temperature-matched EVO drift raises `alert`."""
+        monitor = _new_monitor()
+        specs = _baseline_specs(BASELINE_DAYS)
+        # 7 recent days: superheat +6 K and EVO +20 % at matched outdoor temp.
+        specs += [
+            {"sh": 11.0, "te": -8.0, "evo": 60.0, "outdoor": 7.0} for _ in range(7)
+        ]
+        _feed_days(monitor, specs)
+        status = monitor.get_status()
+        assert status.status == STATUS_ALERT
+        assert status.superheat_delta == pytest.approx(6.0)
+        assert status.exv_delta == pytest.approx(20.0)
+
+    def test_no_false_alert_on_cold_shift(self) -> None:
+        """A colder-weather shift with stable superheat stays `ok`."""
+        monitor = _new_monitor()
+        specs = _baseline_specs(BASELINE_DAYS)
+        # Colder weather: EVO opens and Te drops, but superheat is stable and the
+        # outdoor temperature is outside the match band -> no alert, EVO not compared.
+        specs += [
+            {"sh": 5.0, "te": -12.0, "evo": 62.0, "outdoor": -1.0} for _ in range(7)
+        ]
+        _feed_days(monitor, specs)
+        status = monitor.get_status()
+        assert status.status == STATUS_OK
+        assert status.exv_delta is None
+
+    def test_superheat_drift_capped_at_watch_without_matched_evo(self) -> None:
+        """Strong superheat drift cannot reach `alert` if EVO is not temp-matched."""
+        monitor = _new_monitor()
+        specs = _baseline_specs(BASELINE_DAYS)
+        # Superheat rises strongly but EVO drift cannot be temperature-matched.
+        specs += [
+            {"sh": 12.0, "te": -12.0, "evo": 65.0, "outdoor": -2.0} for _ in range(7)
+        ]
+        _feed_days(monitor, specs)
+        status = monitor.get_status()
+        assert status.status == STATUS_WATCH
+        assert status.exv_delta is None
+
+
+class TestAlertStreak:
+    """The alert streak drives the repair-issue escalation."""
+
+    def test_streak_builds_on_sustained_alert(self) -> None:
+        """The streak grows while the alert condition persists day after day."""
+        monitor = _new_monitor()
+        specs = _baseline_specs(BASELINE_DAYS)
+        specs += [
+            {"sh": 12.0, "te": -8.0, "evo": 65.0, "outdoor": 7.0} for _ in range(10)
+        ]
+        _feed_days(monitor, specs)
+        status = monitor.get_status()
+        assert status.status == STATUS_ALERT
+        assert status.alert_streak >= refr.ALERT_PERSIST_DAYS
+
+    def test_streak_resets_when_recovering(self) -> None:
+        """The streak returns to zero once the readings recover."""
+        monitor = _new_monitor()
+        specs = _baseline_specs(BASELINE_DAYS)
+        specs += [
+            {"sh": 12.0, "te": -8.0, "evo": 65.0, "outdoor": 7.0} for _ in range(6)
+        ]
+        # Recovery: readings return to baseline for several days.
+        specs += [
+            {"sh": 5.0, "te": -5.0, "evo": 40.0, "outdoor": 7.0} for _ in range(7)
+        ]
+        _feed_days(monitor, specs)
+        status = monitor.get_status()
+        assert status.status == STATUS_OK
+        assert status.alert_streak == 0
+
+
+class TestPersistence:
+    """Serialize/restore round-trip and reset."""
+
+    def test_serialize_restore_round_trip(self) -> None:
+        """Restoring a serialized snapshot reproduces the same verdict."""
+        monitor = _new_monitor()
+        specs = _baseline_specs(BASELINE_DAYS)
+        specs += [
+            {"sh": 11.0, "te": -8.0, "evo": 60.0, "outdoor": 7.0} for _ in range(7)
+        ]
+        _feed_days(monitor, specs)
+        before = monitor.get_status()
+
+        state = monitor.serialize()
+        restored = _new_monitor()
+        restored.restore(state)
+        after = restored.get_status()
+
+        assert after.status == before.status
+        assert after.valid_days == before.valid_days
+        assert after.superheat_delta == before.superheat_delta
+        assert after.exv_delta == before.exv_delta
+        # Alert streak and every baseline field must round-trip faithfully.
+        assert before.alert_streak > 0
+        assert after.alert_streak == before.alert_streak
+        assert before.baseline is not None
+        assert after.baseline is not None
+        assert after.baseline.superheat == before.baseline.superheat
+        assert after.baseline.evaporation_temp == before.baseline.evaporation_temp
+        assert after.baseline.exv == before.baseline.exv
+        assert after.baseline.outdoor_temp == before.baseline.outdoor_temp
+        assert after.baseline.days == before.baseline.days
+
+    def test_reset_clears_state(self) -> None:
+        """Resetting drops the baseline and all aggregates."""
+        monitor = _new_monitor()
+        _feed_days(monitor, _baseline_specs(BASELINE_DAYS))
+        assert monitor.get_status().baseline is not None
+
+        monitor.reset()
+        status = monitor.get_status()
+        assert status.status == STATUS_LEARNING
+        assert status.valid_days == 0
+        assert status.baseline is None
+
+
+class TestThresholdBoundaries:
+    """Exactly-at-threshold values pin the >= / <= comparisons."""
+
+    def test_superheat_exactly_watch_threshold(self) -> None:
+        """DSH exactly at SUPERHEAT_WATCH_K classifies as watch."""
+        monitor = _new_monitor()
+        specs = _baseline_specs(BASELINE_DAYS)
+        specs += [
+            {
+                "sh": 5.0 + refr.SUPERHEAT_WATCH_K,
+                "te": -5.0,
+                "evo": 40.0,
+                "outdoor": 7.0,
+            }
+            for _ in range(7)
+        ]
+        _feed_days(monitor, specs)
+        assert monitor.get_status().status == STATUS_WATCH
+
+    def test_exactly_alert_thresholds(self) -> None:
+        """DSH and dEVO both exactly at their alert thresholds classify as alert."""
+        monitor = _new_monitor()
+        specs = _baseline_specs(BASELINE_DAYS)
+        specs += [
+            {
+                "sh": 5.0 + refr.SUPERHEAT_ALERT_K,
+                "te": -8.0,
+                "evo": 40.0 + refr.EVO_ALERT_PCT,
+                "outdoor": 7.0,
+            }
+            for _ in range(7)
+        ]
+        _feed_days(monitor, specs)
+        assert monitor.get_status().status == STATUS_ALERT
+
+    def test_evo_just_below_alert_stays_watch(self) -> None:
+        """Superheat at the alert threshold but EVO just below stays watch."""
+        monitor = _new_monitor()
+        specs = _baseline_specs(BASELINE_DAYS)
+        specs += [
+            {
+                "sh": 5.0 + refr.SUPERHEAT_ALERT_K,
+                "te": -8.0,
+                "evo": 40.0 + refr.EVO_ALERT_PCT - 1.0,
+                "outdoor": 7.0,
+            }
+            for _ in range(7)
+        ]
+        _feed_days(monitor, specs)
+        assert monitor.get_status().status == STATUS_WATCH
+
+    def test_temp_match_inclusive_at_boundary(self) -> None:
+        """An outdoor diff exactly at TEMP_MATCH_K still counts as matched."""
+        monitor = _new_monitor()
+        specs = _baseline_specs(BASELINE_DAYS)  # baseline outdoor = 7.0
+        specs += [
+            {
+                "sh": 11.0,
+                "te": -8.0,
+                "evo": 60.0,
+                "outdoor": 7.0 + refr.TEMP_MATCH_K,
+            }
+            for _ in range(7)
+        ]
+        _feed_days(monitor, specs)
+        status = monitor.get_status()
+        assert status.status == STATUS_ALERT
+        assert status.exv_delta is not None
+
+
+class TestExactAlertStreak:
+    """Deterministic streak arithmetic."""
+
+    def test_streak_equals_expected_after_seven_drift_days(self) -> None:
+        """With EVAL_DAYS=7, 7 leak days after baseline give a streak of 4.
+
+        The recent-window median crosses to the drifted value once >= 4 of the
+        7 trailing days are drift days, so the last 4 daily flushes read alert.
+        """
+        monitor = _new_monitor()
+        specs = _baseline_specs(BASELINE_DAYS)
+        specs += [
+            {"sh": 11.0, "te": -8.0, "evo": 60.0, "outdoor": 7.0} for _ in range(7)
+        ]
+        _feed_days(monitor, specs)
+        assert monitor.get_status().alert_streak == 4
+
+
+def test_multi_day_gap_adds_no_spurious_aggregate() -> None:
+    """A multi-day offline gap produces no phantom day and does not corrupt state."""
+    monitor = _new_monitor()
+    _feed_days(monitor, _baseline_specs(BASELINE_DAYS), start=date(2026, 1, 1))
+    assert monitor.get_status().valid_days == BASELINE_DAYS
+
+    # Resume weeks later: the gap must add no aggregate, only the 7 real days.
+    specs = [{"sh": 11.0, "te": -8.0, "evo": 60.0, "outdoor": 7.0} for _ in range(7)]
+    _feed_days(monitor, specs, start=date(2026, 2, 1))
+
+    status = monitor.get_status()
+    assert status.valid_days == BASELINE_DAYS + 7
+    assert status.status == STATUS_ALERT
+
+
+def test_history_window_is_bounded() -> None:
+    """The daily-aggregate storage never grows past HISTORY_DAYS."""
+    monitor = _new_monitor()
+    _feed_days(monitor, _baseline_specs(HISTORY_DAYS + 10))
+    assert monitor.get_status().valid_days == HISTORY_DAYS


### PR DESCRIPTION
## Description

First iteration of **refrigerant-circuit anomaly detection** (#310): a continuous, local early-warning for a **slow refrigerant charge loss**, built from the compressor signals the integration already reads every poll.

> Advisory only. It **complements** and does **not** replace the mandatory periodic F-Gas leak-tightness inspection.

### What it does
- New domain service `RefrigerantMonitor` (pure, HA-agnostic) reduces per-poll signals into one median **daily aggregate**, freezes a **per-installation baseline** over ~14 heating days, and classifies drift.
- **Suction superheat** (`Tg − Te`) is the primary signal: it is a *regulated* quantity, so it is robust to seasonal variation. The **outdoor expansion valve** (`EVO`) corroborates, but only across days at **equivalent outdoor temperature** (to avoid weather-driven false alarms at the first cold spell). `Te` is informational.
- States: `learning` / `ok` / `watch` / `alert`.

### Surfaces
- `sensor.*_refrigerant_charge_status` — ENUM diagnostic on the Primary Compressor device, with delta/warm-up attributes.
- `button.*_reset_refrigerant_baseline` — re-learn the reference after a top-up or expansion-valve service.
- Self-clearing repair issue when `alert` persists several days.
- Baseline + aggregates + alert streak persisted via a HA `Store` (survives restarts, decoupled from entity enablement).

Gated on `supports_extended_compressor_sensors` (needs `Tg`/`EVO`), so available on every profile **except the Yutampo R32**.

### Design & review
Design spec: `docs/superpowers/specs/2026-07-22-refrigerant-anomaly-detection-design.md`. The design and the implementation were each reviewed by independent agents; findings folded in (Store-based persistence instead of entity extra-data, superheat-primary + temperature-matched EVO to kill seasonal false positives, repair raised from the coordinator update flow, a reset path, boundary/gap/round-trip tests).

### Testing
- `tests/domain/services/test_refrigerant.py`: 31 pure-domain tests (sampling gate, daily aggregation, warm-up, watch/alert, cold-shift non-false-positive, threshold boundaries, multi-day gap, alert streak, serialize/restore, bounded history).
- Full suite: **465 passed**. `make check` clean.

### Limitations (documented)
Warm-up of ~2–3 weeks of heating before it can fire; heating-mode only in this iteration; heuristic thresholds (early-warning hint, not a charge measurement). See `docs/reference/refrigerant-monitoring.md`.

## Checklist

- [x] Tests pass (`make test`)
- [x] Code quality checks pass (`make check`)
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] New/modified entities follow architecture rules
- [x] Documentation updated (reference page, domain-services, entities, AGENT.md)
- [x] Translation keys added to `translations/en.json` (and `fr.json`)

Closes #310
