### PR TITLE
chore: add fleet refrigerant analysis pipeline (backend/analysis)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,7 @@ celerybeat-schedule
 
 # Environments
 .env
+.env.*
 .venv
 env/
 venv/

--- a/backend/README.md
+++ b/backend/README.md
@@ -38,6 +38,8 @@ GROUP BY 1
 ORDER BY points DESC;
 ```
 
+Ready-made analysis scripts built on this pattern (per-model refrigerant profiles, detector replay) live in [analysis/](analysis/README.md).
+
 ## Fleet dashboard (Grafana + Analytics Engine)
 
 Each `installation` payload is mirrored into the Workers Analytics Engine dataset

--- a/backend/analysis/.gitignore
+++ b/backend/analysis/.gitignore
@@ -1,0 +1,2 @@
+# Fleet telemetry extracts are never committed (privacy: no fleet data in the public repo).
+data/

--- a/backend/analysis/README.md
+++ b/backend/analysis/README.md
@@ -1,0 +1,92 @@
+# Fleet refrigerant analysis
+
+Offline analysis pipeline over the telemetry archive (R2 bucket
+`hitachi-telemetry-archive`) that builds **per-model refrigerant operating
+profiles** (`Tg−Te`, `EVO`) and stress-tests the
+[`RefrigerantMonitor`](../../custom_components/hitachi_yutaki/domain/services/refrigerant.py)
+detector (issue [#310](https://github.com/alepee/hass-hitachi_yutaki/issues/310))
+against real fleet behaviour.
+
+First run: 2026-07-22, on 24 days sampled Apr–Jul 2026 (~1.1 M
+compressor-running points, 46 eligible installations). Key findings feeding
+detector iteration 2:
+
+- `compressor_tg_gas_temp` is the **THMg gas-pipe thermistor** (register 1206),
+  not the suction line: `Tg−Te` is a lift-like signal, typically **40–60 K in
+  heating**, not a 2–8 K suction superheat.
+- The detector's `SUPERHEAT_MAX_K = 40` plausibility cap therefore rejects most
+  qualifying heating points on several models (80–90 % on S80, ~98 % on M).
+- Inter-instance spread within a model reaches 26 K → absolute thresholds are
+  impossible; the per-installation learned baseline is the right design, and
+  the per-model bands serve as data-quality sanity checks.
+- In cooling the signal flips sign and EVO pins at 100 %: the detector's
+  heating-only sampling gate is confirmed correct.
+
+> **Privacy**: everything under `data/` is gitignored and must stay out of the
+> repo. Do not republish fleet-wide aggregate counts (instances, per-model
+> totals) in public artifacts (issues, PRs, release notes). See
+> [docs/development/telemetry-dataset.md](../../docs/development/telemetry-dataset.md).
+
+## Prerequisites
+
+- `duckdb` (CLI) and `python3` (stdlib only).
+- R2 S3 read credentials in `backend/.env.r2` (gitignored, never committed):
+
+  ```bash
+  R2_KEY_ID=...
+  R2_SECRET=...
+  ```
+
+  Create them in the Cloudflare dashboard → R2 → *Manage R2 API Tokens* →
+  read-only token scoped to `hitachi-telemetry-archive`.
+
+## Pipeline
+
+```bash
+./pull_installations.sh                     # 1. hash → profile map
+./pull_day.sh 2026-04-02 2026-04-07 ...     # 2. one CSV per fleet-day (~1-2 min each)
+python3 analyze.py                          # 3. per-instance profiles + summary table
+python3 build_model_profiles.py             # 4. per-model roll-up (chart-ready JSON)
+python3 fp_simulation.py                    # 5. false-positive pressure estimate
+```
+
+1. **`pull_installations.sh`** → `data/installations.json`. Maps the 12-char
+   instance hash to its installation payload (profile, capabilities).
+2. **`pull_day.sh YYYY-MM-DD ...`** → `data/days/<day>.csv`. Extracts
+   compressor-running points (defrost excluded) with the refrigerant-relevant
+   fields: `tg`, `te`, `evo`, `outdoor`, `freq`, `op_state`. Already-downloaded
+   days are skipped, so it is resumable and incremental.
+3. **`analyze.py`** → `data/profiles_per_instance.json`. Applies the same
+   qualifying filters as the `RefrigerantMonitor` (frequency band, plausibility
+   ranges — except the 40 K cap, see module docstring), segments by operation
+   mode (`heat` / `dhw` / `cool` / `pool`), aggregates per instance-day
+   (medians, ≥30 samples/day) then per instance, and excludes instances with a
+   phantom `Tg` (register stuck at 0).
+4. **`build_model_profiles.py`** → `data/profiles_per_model.json`. Fleet bands
+   per model × mode and SH/EVO vs outdoor-temperature curves (2 °C bins).
+5. **`fp_simulation.py`** replays the detector's decision rule (baseline →
+   sliding recent window → watch/alert thresholds, EVO temp-matched
+   corroboration) on the collected daily aggregates of the presumed-healthy
+   fleet: any alert condition is a false positive. Compares the as-shipped
+   40 K cap against the proposed 80 K cap. **Needs consecutive heating-season
+   days** to be meaningful — sample a full month of the heating season, not
+   1 day in 5.
+
+## Sampling guidance
+
+- A fleet-day is ~12 k batch files; `pull_day.sh` takes ~1-2 min per day.
+- For **seasonal profiles** (steps 3-4), sparse sampling is fine (e.g. every
+  5th day across months).
+- For **detector replay** (step 5), pull consecutive days of the heating
+  season (e.g. all of January) so the 14-day baseline + 7-day windows match
+  the real detector dynamics.
+
+## Known gaps (as of 2026-07)
+
+- The archive starts in April 2026: **no winter data yet**. There are zero
+  points below 0 °C outdoor; EVO curves and the "superheat is season-robust"
+  assumption must be re-validated on winter 2026-27 data (re-run steps 2-5 on
+  Jan–Feb 2027 days).
+- Metric points only carry what the integration version of each reporter
+  collects: older instances may lack `evo`/`op_state` and drop out of the
+  filters.

--- a/backend/analysis/analyze.py
+++ b/backend/analysis/analyze.py
@@ -1,0 +1,167 @@
+"""Build per-model refrigerant-charge profiles from the sampled telemetry days.
+
+Signal note: `compressor_tg_gas_temp` is the THMg gas-pipe thermistor, NOT the
+suction line — Tg-Te behaves like a lift/discharge-superheat signal (~20-40 K)
+in heating, not a suction superheat (2-8 K). Profiles are segmented by
+operation mode; `heat` is the segment comparable to RefrigerantMonitor.
+"""
+
+import csv
+import json
+import pathlib
+from statistics import median, quantiles
+
+HERE = pathlib.Path(__file__).parent
+DAYS = HERE / "data" / "days"
+INSTALLS = json.loads((HERE / "data" / "installations.json").read_text())
+
+MIN_FREQ, MAX_FREQ = 20.0, 150.0
+MIN_SAMPLES_PER_DAY = 30
+SH_CAP_DETECTOR = 40.0  # RefrigerantMonitor SUPERHEAT_MAX_K
+
+MODE_MAP = {
+    "operation_state_heat_thermo_on": "heat",
+    "operation_state_dhw_on": "dhw",
+    "operation_state_cool_thermo_on": "cool",
+    "operation_state_pool_on": "pool",
+}
+
+
+def load_points():
+    """Yield (hash, day, mode, tg, te, evo, outdoor, freq) for running, plausible points."""
+    for f in sorted(DAYS.glob("*.csv")):
+        day = f.stem
+        with f.open() as fh:
+            for row in csv.DictReader(fh):
+                mode = MODE_MAP.get(row["op_state"])
+                if mode is None:
+                    continue
+                try:
+                    tg = float(row["tg"])
+                    te = float(row["te"])
+                    evo = float(row["evo"])
+                    out = float(row["outdoor"])
+                    freq = float(row["freq"])
+                except (ValueError, TypeError):
+                    continue
+                if not (MIN_FREQ <= freq <= MAX_FREQ):
+                    continue
+                if not (0.0 <= evo <= 100.0):
+                    continue
+                if not (-60.0 <= te <= 40.0) or not (-40.0 <= out <= 40.0):
+                    continue
+                if not (-20.0 <= tg <= 100.0):
+                    continue
+                yield row["hash"], day, mode, tg, te, evo, out, freq
+
+
+def summarize(rows):
+    """Aggregate one instance-mode point list into a profile summary."""
+    by_day: dict[str, list[tuple]] = {}
+    for r in rows:
+        by_day.setdefault(r[0], []).append(r)
+    days = []
+    for day, drows in sorted(by_day.items()):
+        if len(drows) < MIN_SAMPLES_PER_DAY:
+            continue
+        shs = [r[1] - r[2] for r in drows]
+        days.append(
+            {
+                "day": day,
+                "n": len(drows),
+                "sh": round(median(shs), 1),
+                "evo": round(median(r[3] for r in drows), 1),
+                "te": round(median(r[2] for r in drows), 1),
+                "outdoor": round(median(r[4] for r in drows), 1),
+                "freq": round(median(r[5] for r in drows)),
+                "pct_sh_gt40": round(
+                    100 * sum(s > SH_CAP_DETECTOR for s in shs) / len(shs)
+                ),
+            }
+        )
+    if not days:
+        return None
+    valid_days = {d["day"] for d in days}
+    curve: dict[int, dict[str, list[float]]] = {}
+    for day, tg, te, evo, out, _freq in rows:
+        if day not in valid_days:
+            continue
+        b = int(out // 2) * 2
+        c = curve.setdefault(b, {"sh": [], "evo": []})
+        c["sh"].append(tg - te)
+        c["evo"].append(evo)
+    shs = [d["sh"] for d in days]
+    evos = [d["evo"] for d in days]
+    return {
+        "n_valid_days": len(days),
+        "sh_median": round(median(shs), 1),
+        "sh_q1q3": [
+            round(q, 1)
+            for q in (quantiles(shs, n=4)[0::2] if len(shs) >= 2 else [shs[0], shs[0]])
+        ],
+        "evo_median": round(median(evos), 1),
+        "pct_sh_gt40_overall": round(
+            sum(d["pct_sh_gt40"] * d["n"] for d in days) / sum(d["n"] for d in days)
+        ),
+        "days": days,
+        "curve": {
+            str(b): {
+                "n": len(c["sh"]),
+                "sh": round(median(c["sh"]), 1),
+                "evo": round(median(c["evo"]), 1),
+            }
+            for b, c in sorted(curve.items())
+            if len(c["sh"]) >= 20
+        },
+    }
+
+
+def main():
+    pts: dict[tuple[str, str], list[tuple]] = {}
+    tg_all: dict[str, list[float]] = {}
+    for h, day, mode, tg, te, evo, out, freq in load_points():
+        pts.setdefault((h, mode), []).append((day, tg, te, evo, out, freq))
+        tg_all.setdefault(h, []).append(tg)
+
+    phantom = {h for h, tgs in tg_all.items() if median(tgs) < 5.0}
+
+    result: dict[str, dict] = {}
+    for (h, mode), rows in pts.items():
+        if h in phantom:
+            continue
+        s = summarize(rows)
+        if s is None:
+            continue
+        inst = result.setdefault(
+            h, {"profile": INSTALLS.get(h, {}).get("profile", "unknown"), "modes": {}}
+        )
+        inst["modes"][mode] = s
+
+    out = {"phantom_excluded": sorted(phantom), "instances": result}
+    (HERE / "data" / "profiles_per_instance.json").write_text(json.dumps(out, indent=1))
+
+    for mode in ["heat", "dhw", "cool"]:
+        by_model: dict[str, list] = {}
+        for inst in result.values():
+            if mode in inst["modes"]:
+                by_model.setdefault(inst["profile"], []).append(inst["modes"][mode])
+        if not by_model:
+            continue
+        print(f"\n=== mode {mode} ===")
+        print(
+            f"{'model':16} {'inst':>4} {'SH med K':>9} {'SH inst range':>15} {'EVO med %':>9} {'%pts SH>40':>10}"
+        )
+        for model, insts in sorted(by_model.items()):
+            shs = [r["sh_median"] for r in insts]
+            evos = [r["evo_median"] for r in insts]
+            p40 = [r["pct_sh_gt40_overall"] for r in insts]
+            print(
+                f"{model:16} {len(insts):>4} {median(shs):>9.1f} "
+                f"{f'{min(shs):.0f}..{max(shs):.0f}':>15} {median(evos):>9.1f} "
+                f"{f'{min(p40)}..{max(p40)}':>10}"
+            )
+    print("\nphantom Tg (excluded):", len(phantom))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/analysis/build_model_profiles.py
+++ b/backend/analysis/build_model_profiles.py
@@ -1,0 +1,92 @@
+"""Roll instance profiles up to per-model refrigerant profiles.
+
+Reads data/profiles_per_instance.json (produced by analyze.py) and writes
+data/profiles_per_model.json: per model x mode, the fleet band (median /
+min / max of instance medians), the per-instance summaries, and the
+SH / EVO vs outdoor-temperature curves (2 degree C bins, median across
+instances, bins kept when >= 2 instances contribute).
+
+Instances whose reported profile is `yutampo_r32` are excluded: that model
+has no refrigerant-circuit registers, so refrigerant-looking data under that
+profile indicates a profile misdetection, not a Yutampo.
+"""
+
+import json
+import pathlib
+from statistics import median
+
+HERE = pathlib.Path(__file__).parent
+
+
+def main() -> None:
+    data = json.loads((HERE / "data" / "profiles_per_instance.json").read_text())
+
+    models: dict[str, dict] = {}
+    for h, inst in data["instances"].items():
+        p = inst["profile"]
+        if p == "yutampo_r32":
+            continue
+        for mode, s in inst["modes"].items():
+            m = models.setdefault(p, {}).setdefault(
+                mode, {"instances": [], "curves": {}}
+            )
+            m["instances"].append(
+                {
+                    "hash": h[:6],
+                    "sh_median": s["sh_median"],
+                    "sh_q1q3": s["sh_q1q3"],
+                    "evo_median": s["evo_median"],
+                    "n_valid_days": s["n_valid_days"],
+                    "pct_sh_gt40": s["pct_sh_gt40_overall"],
+                }
+            )
+            for b, c in s["curve"].items():
+                bin_ = m["curves"].setdefault(int(b), {"sh": [], "evo": []})
+                bin_["sh"].append(c["sh"])
+                bin_["evo"].append(c["evo"])
+
+    out: dict[str, dict] = {}
+    for p, mm in models.items():
+        out[p] = {}
+        for mode, m in mm.items():
+            min_inst = 2 if len(m["instances"]) >= 3 else 1
+            curve = [
+                {
+                    "t": b,
+                    "n_inst": len(c["sh"]),
+                    "sh": round(median(c["sh"]), 1),
+                    "sh_min": min(c["sh"]),
+                    "sh_max": max(c["sh"]),
+                    "evo": round(median(c["evo"]), 1),
+                    "evo_min": min(c["evo"]),
+                    "evo_max": max(c["evo"]),
+                }
+                for b, c in sorted(m["curves"].items())
+                if len(c["sh"]) >= min_inst
+            ]
+            shs = [i["sh_median"] for i in m["instances"]]
+            evos = [i["evo_median"] for i in m["instances"]]
+            out[p][mode] = {
+                "n_instances": len(m["instances"]),
+                "sh_median": round(median(shs), 1),
+                "sh_min": min(shs),
+                "sh_max": max(shs),
+                "evo_median": round(median(evos), 1),
+                "evo_min": min(evos),
+                "evo_max": max(evos),
+                "instances": sorted(m["instances"], key=lambda i: i["sh_median"]),
+                "curve": curve,
+            }
+
+    (HERE / "data" / "profiles_per_model.json").write_text(json.dumps(out, indent=1))
+    for p, mm in sorted(out.items()):
+        for mode, m in sorted(mm.items()):
+            print(
+                f"{p:16} {mode:5} n={m['n_instances']:<3} "
+                f"SH {m['sh_median']} [{m['sh_min']}..{m['sh_max']}] K  "
+                f"EVO {m['evo_median']} %"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/analysis/fp_simulation.py
+++ b/backend/analysis/fp_simulation.py
@@ -1,0 +1,149 @@
+"""Replay the RefrigerantMonitor decision rule on real fleet data.
+
+The fleet is presumed healthy over the analysed window, so every alert
+condition produced by the replay is a false positive, and the share of
+instances stuck without a baseline measures detector availability.
+
+Faithful to domain/services/refrigerant.py:
+  - qualifying samples: heating mode, frequency 20-150 Hz, plausibility ranges
+    (the SH cap is a parameter: 40 K as shipped, 80 K proposed);
+  - valid day: >= 30 qualifying samples, daily aggregate = medians;
+  - baseline: frozen over the first 14 valid days;
+  - verdict: recent = last 7 valid days (>= 3), delta_SH vs baseline;
+    WATCH at >= 3 K; ALERT at >= 5 K corroborated by delta_EVO >= 15 pts over
+    recent days outdoor-matched to the baseline (±4 K, >= 3 matched);
+  - repair issue: ALERT on >= 3 consecutive valid days.
+
+Meaningful only on CONSECUTIVE heating-season days (see README.md).
+"""
+
+import csv
+import json
+import pathlib
+from statistics import median
+
+HERE = pathlib.Path(__file__).parent
+DAYS = HERE / "data" / "days"
+INSTALLS = json.loads((HERE / "data" / "installations.json").read_text())
+
+MIN_FREQ, MAX_FREQ = 20.0, 150.0
+MIN_SAMPLES_PER_DAY = 30
+BASELINE_DAYS = 14
+EVAL_DAYS = 7
+MIN_EVAL_DAYS = 3
+TEMP_MATCH_K = 4.0
+SUPERHEAT_WATCH_K = 3.0
+SUPERHEAT_ALERT_K = 5.0
+EVO_ALERT_PCT = 15.0
+ALERT_PERSIST_DAYS = 3
+
+
+def daily_aggregates(sh_cap: float) -> dict[str, list[tuple]]:
+    """Return {hash: [(day, sh, evo, outdoor), ...]} for heating mode."""
+    buf: dict[tuple[str, str], dict[str, list[float]]] = {}
+    for f in sorted(DAYS.glob("*.csv")):
+        day = f.stem
+        with f.open() as fh:
+            for row in csv.DictReader(fh):
+                if row["op_state"] != "operation_state_heat_thermo_on":
+                    continue
+                try:
+                    tg, te = float(row["tg"]), float(row["te"])
+                    evo, out = float(row["evo"]), float(row["outdoor"])
+                    freq = float(row["freq"])
+                except (ValueError, TypeError):
+                    continue
+                if not (MIN_FREQ <= freq <= MAX_FREQ):
+                    continue
+                sh = tg - te
+                if not (-10.0 <= sh <= sh_cap):
+                    continue
+                if not (0.0 <= evo <= 100.0) or not (-60.0 <= te <= 40.0):
+                    continue
+                d = buf.setdefault((row["hash"], day), {"sh": [], "evo": [], "out": []})
+                d["sh"].append(sh)
+                d["evo"].append(evo)
+                d["out"].append(out)
+    result: dict[str, list[tuple]] = {}
+    for (h, day), v in sorted(buf.items()):
+        if len(v["sh"]) < MIN_SAMPLES_PER_DAY:
+            continue
+        result.setdefault(h, []).append(
+            (day, median(v["sh"]), median(v["evo"]), median(v["out"]))
+        )
+    return result
+
+
+def simulate(sh_cap: float, label: str) -> None:
+    aggs = daily_aggregates(sh_cap)
+    n_inst = with_baseline = evals = watch = alert_cond = issues = 0
+    detail = []
+    for h, days in sorted(aggs.items()):
+        profile = INSTALLS.get(h, {}).get("profile", "?")
+        if profile == "yutampo_r32":
+            continue
+        n_inst += 1
+        if len(days) < BASELINE_DAYS + MIN_EVAL_DAYS:
+            continue
+        with_baseline += 1
+        base = days[:BASELINE_DAYS]
+        b_sh = median(d[1] for d in base)
+        b_evo = median(d[2] for d in base)
+        b_out = median(d[3] for d in base)
+        inst_watch = inst_alert = inst_evals = streak = inst_issues = 0
+        worst = 0.0
+        for i in range(BASELINE_DAYS + MIN_EVAL_DAYS, len(days) + 1):
+            recent = days[max(0, i - EVAL_DAYS) : i]
+            if len(recent) < MIN_EVAL_DAYS:
+                continue
+            inst_evals += 1
+            d_sh = median(d[1] for d in recent) - b_sh
+            worst = max(worst, d_sh)
+            matched = [d for d in recent if abs(d[3] - b_out) <= TEMP_MATCH_K]
+            d_evo = (
+                median(d[2] for d in matched) - b_evo
+                if len(matched) >= MIN_EVAL_DAYS
+                else None
+            )
+            if (
+                d_sh >= SUPERHEAT_ALERT_K
+                and d_evo is not None
+                and d_evo >= EVO_ALERT_PCT
+            ):
+                inst_alert += 1
+                streak += 1
+                if streak == ALERT_PERSIST_DAYS:
+                    inst_issues += 1
+            else:
+                streak = 0
+                if d_sh >= SUPERHEAT_WATCH_K:
+                    inst_watch += 1
+        evals += inst_evals
+        watch += inst_watch
+        alert_cond += inst_alert
+        issues += inst_issues
+        flag = " <-- would raise repair issue" if inst_issues else ""
+        if inst_watch or inst_alert:
+            detail.append(
+                f"    {profile} {h[:6]}: {len(days)} valid days, worst dSH +{worst:.1f} K, "
+                f"watch {inst_watch}/{inst_evals} d, alert {inst_alert}/{inst_evals} d{flag}"
+            )
+    print(f"\n== {label} (SH cap {sh_cap:.0f} K) ==")
+    print(f"  instances with heating data: {n_inst}")
+    if n_inst:
+        print(
+            f"  reaching a baseline (>= {BASELINE_DAYS + MIN_EVAL_DAYS} valid days): "
+            f"{with_baseline} ({100 * with_baseline / n_inst:.0f}% availability)"
+        )
+    if evals:
+        print(
+            f"  instance-day verdicts: {evals} | WATCH: {watch} ({100 * watch / evals:.1f}%) | "
+            f"ALERT condition: {alert_cond} ({100 * alert_cond / evals:.1f}%) | repair issues: {issues}"
+        )
+    for line in detail:
+        print(line)
+
+
+if __name__ == "__main__":
+    simulate(40.0, "as shipped")
+    simulate(80.0, "proposed fix")

--- a/backend/analysis/pull_day.sh
+++ b/backend/analysis/pull_day.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Pull one day of compressor-running metric points from the R2 telemetry
+# archive into data/days/<day>.csv, via DuckDB + httpfs (~1-2 min per fleet-day).
+#
+# Keeps only points where the compressor runs and the defrost guard is off;
+# columns: hash, time, tg, te, evo, outdoor, freq, op_state.
+#
+# Requires: duckdb, R2 S3 credentials in ../.env.r2 (see README.md).
+# Usage: pull_day.sh YYYY-MM-DD [YYYY-MM-DD ...]
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+mkdir -p "$HERE/data/days"
+source "$HERE/../.env.r2"
+
+for DAY in "$@"; do
+  Y="${DAY:0:4}"; M="${DAY:5:2}"; D="${DAY:8:2}"
+  OUT="$HERE/data/days/$DAY.csv"
+  if [ -f "$OUT" ]; then echo "$DAY: already done"; continue; fi
+
+  duckdb -c "
+INSTALL httpfs; LOAD httpfs;
+CREATE SECRET r2 (
+  TYPE s3,
+  KEY_ID '$R2_KEY_ID',
+  SECRET '$R2_SECRET',
+  REGION 'auto',
+  ENDPOINT '04cd76fb78280d03639e8d948d7ae410.r2.cloudflarestorage.com'
+);
+SET threads = 32;
+COPY (
+  SELECT
+    instance_hash[1:12]                                                          AS hash,
+    json_extract_string(p.value, '$.time')                                       AS time,
+    TRY_CAST(json_extract(p.value, '$.compressor_tg_gas_temp') AS DOUBLE)        AS tg,
+    TRY_CAST(json_extract(p.value, '$.compressor_te_evaporator_temp') AS DOUBLE) AS te,
+    TRY_CAST(json_extract(p.value, '$.compressor_evo_outdoor_expansion_valve_opening') AS DOUBLE) AS evo,
+    TRY_CAST(json_extract(p.value, '$.outdoor_temp') AS DOUBLE)                  AS outdoor,
+    TRY_CAST(json_extract(p.value, '$.compressor_frequency') AS DOUBLE)          AS freq,
+    json_extract_string(p.value, '$.operation_state')                            AS op_state
+  FROM read_json(
+         's3://hitachi-telemetry-archive/metrics/year=$Y/month=$M/day=$D/batch_*.json',
+         columns = {instance_hash: 'VARCHAR', points: 'JSON'}
+       ),
+       json_each(points) AS p
+  WHERE TRY_CAST(json_extract(p.value, '$.compressor_frequency') AS DOUBLE) > 0
+    AND COALESCE(TRY_CAST(json_extract(p.value, '$.is_defrosting') AS BOOLEAN), false) = false
+) TO '$OUT' (HEADER, DELIMITER ',');
+"
+  echo "$DAY: $(($(wc -l < "$OUT") - 1)) running-points"
+done

--- a/backend/analysis/pull_installations.sh
+++ b/backend/analysis/pull_installations.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Download all installation payloads from the R2 telemetry archive into
+# data/installations.json ({hash12: installation_data}), used by analyze.py
+# to map instances to heat-pump profiles.
+#
+# Requires: duckdb, python3, R2 S3 credentials in ../.env.r2 (see README.md).
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+mkdir -p "$HERE/data"
+source "$HERE/../.env.r2"
+
+duckdb -c "
+INSTALL httpfs; LOAD httpfs;
+CREATE SECRET r2 (
+  TYPE s3,
+  KEY_ID '$R2_KEY_ID',
+  SECRET '$R2_SECRET',
+  REGION 'auto',
+  ENDPOINT '04cd76fb78280d03639e8d948d7ae410.r2.cloudflarestorage.com'
+);
+COPY (
+  SELECT instance_hash[1:12] AS hash, data
+  FROM read_json(
+    's3://hitachi-telemetry-archive/installations/install_*.json',
+    columns = {instance_hash: 'VARCHAR', data: 'JSON'}
+  )
+) TO '$HERE/data/installations_raw.json' (FORMAT json, ARRAY true);
+"
+
+python3 - "$HERE" <<'EOF'
+import json, pathlib, sys
+
+here = pathlib.Path(sys.argv[1])
+raw = json.loads((here / "data" / "installations_raw.json").read_text())
+out = {r["hash"]: (json.loads(r["data"]) if isinstance(r["data"], str) else r["data"]) for r in raw}
+(here / "data" / "installations.json").write_text(json.dumps(out, indent=1))
+(here / "data" / "installations_raw.json").unlink()
+print(f"{len(out)} installations")
+EOF

--- a/docs/development/telemetry-dataset.md
+++ b/docs/development/telemetry-dataset.md
@@ -61,6 +61,8 @@ LIMIT 1;
 
 Performance: globbing thousands of JSON files over `httpfs` is HTTP-HEAD-bound (~10 files/s/thread). Acceptable for a single-day fleet scan or a single-instance multi-day scan; narrow the partition glob.
 
+For fleet-wide analyses (rather than single fixtures), reusable DuckDB-based scripts live in [backend/analysis/](../../backend/analysis/README.md): per-day metric extraction, per-model refrigerant profiles, and a detector replay for false-positive estimation. Credentials go in the gitignored `backend/.env.r2` (`R2_KEY_ID=` / `R2_SECRET=`).
+
 ## Turning a snapshot into a fixture
 
 Trim a real snapshot to the fields a test needs, then feed those register values into a test. Tests in this repo build register data inline as Python dicts (see `tests/` for examples, e.g. the `system_config`-driven capability tests in `tests/test_coordinator_capability_flags.py`) rather than loading JSON fixtures, so a real snapshot is best used as the source of the numbers you hard-code, with a provenance comment noting it is real field data. A DHW-only Yutampo R32, for instance, reports `system_config = 16` with phantom water/compressor registers reading a constant `0` rather than a sentinel.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,3 +166,4 @@ max-complexity = 25
 # Allow print and missing main docstring in CLI dev scripts
 [tool.ruff.lint.per-file-ignores]
 "scripts/*" = ["D103", "T201"]
+"backend/analysis/*" = ["D103", "T201"]


### PR DESCRIPTION
## Description

Adds a reusable, offline analysis pipeline over the telemetry archive (R2) that builds per-model refrigerant operating profiles (`Tg−Te`, `EVO`) and replays the `RefrigerantMonitor` decision rule on real fleet data to estimate false-positive pressure and availability. Groundwork for #310 iteration 2 (notably the `SUPERHEAT_MAX_K` recalibration) and for the winter 2026-27 re-run that will extend the profiles below 0 °C outdoor.

- `backend/analysis/pull_installations.sh` / `pull_day.sh`: DuckDB + httpfs extraction (hash → profile map, one CSV per fleet-day of compressor-running points).
- `backend/analysis/analyze.py` / `build_model_profiles.py`: per-instance then per-model profiles, segmented by operation mode, with RefrigerantMonitor-like qualifying filters.
- `backend/analysis/fp_simulation.py`: faithful detector replay (14-day baseline, 7-day window, conjunctive SH+EVO alert, 3-day persistence), comparing the as-shipped 40 K cap with the proposed 80 K cap.
- Everything under `backend/analysis/data/` is gitignored (no fleet data in the repo); R2 credentials come from the gitignored `backend/.env.r2` (`.env.*` added to the root `.gitignore`).
- Doc pointers added in `backend/README.md` and `docs/development/telemetry-dataset.md`; ruff `per-file-ignores` extended to `backend/analysis/*` (CLI scripts, `print` allowed).

No integration code touched; no user-facing change.

## Checklist

- [x] Tests pass (`make test`) — not applicable, no integration code touched
- [x] Code quality checks pass (`make check`)
- [x] `CHANGELOG.md` updated under `[Unreleased]` (or `skip-changelog` label added)
- [x] New/modified entities follow [architecture rules](docs/architecture.md) — not applicable
- [x] Documentation updated for any behavior/architecture/register/entity/workflow change (see the code-area → doc map in [AGENT.md](AGENT.md#keeping-documentation-in-sync))
- [x] Translation keys added to `translations/en.json` (if applicable) — not applicable