### PR TITLE
fix: clean up refrigerant Store and per-entry repair issues on entry removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Removing the integration's config entry now cleans up everything it persisted: the refrigerant detector's baseline file (`.storage/hitachi_yutaki_refrigerant_<entry_id>`) and the per-entry repair issues (refrigerant charge alert, missing configuration, telemetry and energy-cost onboarding). Domain-wide issues (`connection_error`, gateway desync/initializing warnings) are also swept when the last entry is removed. Previously these were orphaned forever after deleting the entry (#385).
+
 ## [2.2.0-beta.2] - 2026-07-22
 
 ### Added

--- a/custom_components/hitachi_yutaki/__init__.py
+++ b/custom_components/hitachi_yutaki/__init__.py
@@ -14,11 +14,16 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.instance_id import async_get as async_get_instance_id
-from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
+from homeassistant.helpers.issue_registry import (
+    IssueSeverity,
+    async_create_issue,
+    async_delete_issue,
+)
 from homeassistant.helpers.restore_state import async_get as async_get_restore_data
+from homeassistant.helpers.storage import Store
 from homeassistant.loader import async_get_integration
 
-from .adapters.derived_metrics import DerivedMetricsAdapter
+from .adapters.derived_metrics import REFRIGERANT_STORE_VERSION, DerivedMetricsAdapter
 from .api import GATEWAY_INFO, create_register_map
 from .const import (
     CIRCUIT_MODE_COOLING,
@@ -771,3 +776,33 @@ async def async_unload_entry(
         _LOGGER.info("Hitachi Yutaki integration unloaded successfully")
 
     return unload_ok
+
+
+async def async_remove_entry(
+    hass: HomeAssistant, entry: HitachiYutakiConfigEntry
+) -> None:
+    """Clean up per-entry persistent artefacts when the entry is removed.
+
+    Called by HA after unload, once the entry is already gone from the
+    registry, so ``entry.runtime_data`` is unavailable here.
+    """
+    # Refrigerant detector Store (.storage/hitachi_yutaki_refrigerant_<entry_id>).
+    # Only extended-sensor profiles create it; async_remove is a no-op otherwise.
+    await Store(
+        hass, REFRIGERANT_STORE_VERSION, f"{DOMAIN}_refrigerant_{entry.entry_id}"
+    ).async_remove()
+
+    # Per-entry repair issues (async_delete_issue is idempotent).
+    for issue_id in (
+        f"missing_config_{entry.entry_id}",
+        f"enable_energy_cost_{entry.entry_id}",
+        f"enable_telemetry_{entry.entry_id}",
+        f"refrigerant_charge_alert_{entry.entry_id}",
+    ):
+        async_delete_issue(hass, DOMAIN, issue_id)
+
+    # Domain-global issues are shared across entries: sweep them only when the
+    # removed entry was the last one (it is already absent from the registry).
+    if not hass.config_entries.async_entries(DOMAIN):
+        for issue_id in ("connection_error", "desync_warning", "initializing_warning"):
+            async_delete_issue(hass, DOMAIN, issue_id)

--- a/docs/reference/refrigerant-monitoring.md
+++ b/docs/reference/refrigerant-monitoring.md
@@ -78,6 +78,9 @@ After a **legitimate refrigerant top-up or expansion-valve service**, press **Re
 Refrigerant Baseline** so a fresh reference is learned; otherwise the stale baseline would
 keep alerting.
 
+The `Store` (`.storage/hitachi_yutaki_refrigerant_<entry_id>`) is deleted automatically when
+the config entry is removed (`async_remove_entry`), leaving no orphaned baseline behind.
+
 ## Limitations (expected)
 
 - **Warm-up:** needs ~2–3 weeks of heating operation before it can leave `learning`. Off

--- a/tests/test_init_remove_entry.py
+++ b/tests/test_init_remove_entry.py
@@ -1,0 +1,178 @@
+"""Tests for async_remove_entry cleanup of per-entry persistent artefacts."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.hitachi_yutaki import async_remove_entry
+from custom_components.hitachi_yutaki.adapters.derived_metrics import (
+    REFRIGERANT_STORE_VERSION,
+)
+from custom_components.hitachi_yutaki.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers.issue_registry import IssueSeverity
+from homeassistant.helpers.storage import Store
+
+
+def _make_entry(entry_id: str = "test_entry_id") -> MockConfigEntry:
+    """Create a mock config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="Hitachi Heat Pump",
+        data={"name": "Hitachi Heat Pump"},
+        entry_id=entry_id,
+    )
+
+
+def _store_key(entry_id: str) -> str:
+    """Return the refrigerant Store key for an entry."""
+    return f"{DOMAIN}_refrigerant_{entry_id}"
+
+
+def _create_per_entry_issues(hass: HomeAssistant, entry_id: str) -> list[str]:
+    """Create the four per-entry repair issues and return their ids."""
+    issue_ids = [
+        f"missing_config_{entry_id}",
+        f"enable_energy_cost_{entry_id}",
+        f"enable_telemetry_{entry_id}",
+        f"refrigerant_charge_alert_{entry_id}",
+    ]
+    for issue_id in issue_ids:
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            issue_id,
+            is_fixable=False,
+            severity=IssueSeverity.WARNING,
+            translation_key="connection_error",
+        )
+    return issue_ids
+
+
+async def test_store_deleted(hass: HomeAssistant, hass_storage: dict[str, Any]) -> None:
+    """The refrigerant Store is removed when the entry is removed."""
+    entry = _make_entry()
+    store = Store(hass, REFRIGERANT_STORE_VERSION, _store_key(entry.entry_id))
+    await store.async_save({"baseline": 42})
+
+    assert _store_key(entry.entry_id) in hass_storage
+
+    await async_remove_entry(hass, entry)
+
+    assert _store_key(entry.entry_id) not in hass_storage
+
+
+async def test_no_store_is_noop(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    """Removing an entry with no Store raises no exception."""
+    entry = _make_entry()
+
+    await async_remove_entry(hass, entry)
+
+    assert _store_key(entry.entry_id) not in hass_storage
+
+
+async def test_per_entry_issues_deleted(hass: HomeAssistant) -> None:
+    """The four per-entry repair issues are deleted on entry removal."""
+    entry = _make_entry()
+    issue_ids = _create_per_entry_issues(hass, entry.entry_id)
+
+    registry = ir.async_get(hass)
+    for issue_id in issue_ids:
+        assert registry.async_get_issue(DOMAIN, issue_id) is not None
+
+    await async_remove_entry(hass, entry)
+
+    for issue_id in issue_ids:
+        assert registry.async_get_issue(DOMAIN, issue_id) is None
+
+
+async def test_global_issues_preserved_when_another_entry_remains(
+    hass: HomeAssistant,
+) -> None:
+    """Domain-global issues survive while another entry still exists."""
+    entry = _make_entry("first_entry")
+    other = _make_entry("second_entry")
+    other.add_to_hass(hass)
+
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        "connection_error",
+        is_fixable=False,
+        severity=IssueSeverity.ERROR,
+        translation_key="connection_error",
+    )
+
+    await async_remove_entry(hass, entry)
+
+    registry = ir.async_get(hass)
+    assert registry.async_get_issue(DOMAIN, "connection_error") is not None
+
+
+async def test_global_issues_swept_on_last_removal(hass: HomeAssistant) -> None:
+    """Domain-global issues are swept when the last entry is removed."""
+    entry = _make_entry()
+
+    global_ids = ("connection_error", "desync_warning", "initializing_warning")
+    for issue_id in global_ids:
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            issue_id,
+            is_fixable=False,
+            severity=IssueSeverity.WARNING,
+            translation_key="connection_error",
+        )
+
+    await async_remove_entry(hass, entry)
+
+    registry = ir.async_get(hass)
+    for issue_id in global_ids:
+        assert registry.async_get_issue(DOMAIN, issue_id) is None
+
+
+async def test_end_to_end_removal(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    """Removing a NOT_LOADED entry via HA cleans up store and issues.
+
+    The entry is the last one of the domain, so the removal must also sweep
+    the domain-global issues through the real ``async_remove`` path.
+    """
+    entry = _make_entry()
+    entry.add_to_hass(hass)
+
+    store = Store(hass, REFRIGERANT_STORE_VERSION, _store_key(entry.entry_id))
+    await store.async_save({"baseline": 42})
+    assert _store_key(entry.entry_id) in hass_storage
+
+    issue_id = f"missing_config_{entry.entry_id}"
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        issue_id,
+        is_fixable=False,
+        severity=IssueSeverity.WARNING,
+        translation_key="connection_error",
+    )
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        "connection_error",
+        is_fixable=False,
+        severity=IssueSeverity.ERROR,
+        translation_key="connection_error",
+    )
+
+    await hass.config_entries.async_remove(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert _store_key(entry.entry_id) not in hass_storage
+    registry = ir.async_get(hass)
+    assert registry.async_get_issue(DOMAIN, issue_id) is None
+    assert registry.async_get_issue(DOMAIN, "connection_error") is None


### PR DESCRIPTION
## Description

The integration defined no `async_remove_entry` hook, so deleting the config entry orphaned the refrigerant detector's Store file (`.storage/hitachi_yutaki_refrigerant_<entry_id>`) forever, and left dead repair issues in the registry (found during the adversarial review of #310).

New `async_remove_entry` in `__init__.py`:

- removes the refrigerant Store (the only per-entry Store the integration writes; thermal/energy restore state lives in HA core's `restore_state` cache, which HA cleans up itself);
- deletes the four per-entry repair issues: `missing_config_`, `enable_energy_cost_`, `enable_telemetry_`, `refrigerant_charge_alert_` + entry_id;
- sweeps the three domain-global issues (`connection_error`, `desync_warning`, `initializing_warning`) **only when the removed entry was the last one**. One correction vs the issue text: `connection_error` is domain-global, not per-entry, so deleting it unconditionally would clear a live warning belonging to another entry.

HA calls the hook after unload and after the entry is gone from the registry, so `entry.runtime_data` is unavailable there: the Store handle is rebuilt from the imported key/version constants.

### Testing

- New `tests/test_init_remove_entry.py` (6 tests): store removed, no-store no-op, per-entry issues deleted, global issues preserved while another entry remains, global issues swept on last removal, and an end-to-end run through `hass.config_entries.async_remove` asserting both the store cleanup and the global sweep.
- Full suite: **471 passed**. `make check` clean.

## Checklist

- [x] Tests pass (`make test`)
- [x] Code quality checks pass (`make check`)
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] New/modified entities follow architecture rules (no entity change)
- [x] Documentation updated (`docs/reference/refrigerant-monitoring.md`, persistence section)
- [x] Translation keys added to `translations/en.json` (n/a, no new keys)

Closes #385
