### PR TITLE
fix: stop reporting enrichment failures as gateway connection_error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Coordinator: a crash in a post-fetch stage (derived-metrics enrichment, refrigerant repair-issue update, telemetry collection or `system_config` persistence) was misreported as a gateway `connection_error` repair issue and marked every entity unavailable, even though the Modbus poll had returned complete valid register data. Such failures are now logged with a full stack trace as integration bugs and the raw register data is returned: register-backed entities keep updating and no `connection_error` issue is raised (derived sensors may read `unknown` for the affected cycles). Real Modbus/communication failures keep the exact previous behavior: `connection_error` issue, `UpdateFailed`, and gateway-not-ready backoff (#386).
+
 ## [2.2.0-beta.2] - 2026-07-22
 
 ### Added

--- a/custom_components/hitachi_yutaki/coordinator.py
+++ b/custom_components/hitachi_yutaki/coordinator.py
@@ -159,6 +159,33 @@ class HitachiYutakiDataCoordinator(DataUpdateCoordinator):
 
             self.system_config = data.get("system_config", 0)
 
+            # Poll succeeded: clear any connection error issue now, before
+            # the post-fetch stages, so an enrichment bug cannot keep it
+            # alive or re-create it.
+            ir.async_delete_issue(self.hass, DOMAIN, "connection_error")
+
+        except UpdateFailed:
+            # Re-raise so the generic Exception handler below doesn't
+            # turn our intentional UpdateFailed into an HA issue.
+            raise
+
+        except Exception as exc:
+            ir.async_create_issue(
+                self.hass,
+                DOMAIN,
+                "connection_error",
+                is_fixable=False,
+                severity=ir.IssueSeverity.ERROR,
+                translation_key="connection_error",
+            )
+            _LOGGER.warning("Error communicating with Hitachi Yutaki gateway: %s", exc)
+            raise UpdateFailed("Failed to communicate with device") from exc
+
+        # Post-fetch stages: bookkeeping and pure computation on registers
+        # already fetched. A failure here is a software bug, not a gateway
+        # communication error: log it with a stack trace and return the raw
+        # poll data so register-backed entities stay fresh (#386).
+        try:
             # Persist system_config in entry.data so COP services and device
             # capabilities can be initialised at next setup *before* any
             # refresh — survives reloads that hit gateway_not_ready (#308).
@@ -182,9 +209,6 @@ class HitachiYutakiDataCoordinator(DataUpdateCoordinator):
                 self.derived_metrics.update(data)
                 self._update_refrigerant_issue()
 
-            # If we reach here, connection is successful, so delete any connection error issue
-            ir.async_delete_issue(self.hass, DOMAIN, "connection_error")
-
             # Telemetry: collect metrics from this poll cycle
             # (collector handles level=OFF internally)
             self.telemetry_collector.collect(data)
@@ -197,25 +221,13 @@ class HitachiYutakiDataCoordinator(DataUpdateCoordinator):
             # Fire-and-forget to avoid blocking the Modbus poll path
             if not self._installation_info_sent or not self._snapshot_sent:
                 self.hass.async_create_task(self._send_onetime_telemetry(data))
-
-            return data
-
-        except UpdateFailed:
-            # Re-raise so the generic Exception handler below doesn't
-            # turn our intentional UpdateFailed into an HA issue.
-            raise
-
-        except Exception as exc:
-            ir.async_create_issue(
-                self.hass,
-                DOMAIN,
-                "connection_error",
-                is_fixable=False,
-                severity=ir.IssueSeverity.ERROR,
-                translation_key="connection_error",
+        except Exception:
+            _LOGGER.exception(
+                "Post-fetch enrichment failed; returning raw poll data "
+                "(this is an integration bug, not a gateway problem)"
             )
-            _LOGGER.warning("Error communicating with Hitachi Yutaki gateway: %s", exc)
-            raise UpdateFailed("Failed to communicate with device") from exc
+
+        return data
 
     async def _send_onetime_telemetry(self, data: dict[str, Any]) -> None:
         """Send one-time telemetry (installation info + snapshot) with backoff."""

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -215,6 +215,8 @@ Data moves through the layers in a single direction during each polling cycle. T
 
 Modbus registers --> API client --> Coordinator cache --> Domain services --> Entity classes --> HA state machine
 
+Failure attribution follows the same boundary: only errors in the fetch path (connect, register reads) raise `UpdateFailed` and surface the `connection_error` repair issue; a failure in a post-fetch stage (derived-metrics enrichment, refrigerant issue update, telemetry collection) is logged as an integration bug with a stack trace and the raw register data is still returned, so register-backed entities remain available.
+
 ## Domain-to-Entity Matrix
 
 | Domain | Sensor | Binary Sensor | Switch | Number | Climate | Water Heater | Select | Button |

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from custom_components.hitachi_yutaki.api.base import ReadResult
+from custom_components.hitachi_yutaki.const import DOMAIN
 from custom_components.hitachi_yutaki.coordinator import HitachiYutakiDataCoordinator
 from custom_components.hitachi_yutaki.telemetry import (
     NoopTelemetryClient,
@@ -177,3 +178,93 @@ async def test_gateway_not_ready_property_false_after_recovery(
         await coordinator._async_update_data()
 
     assert coordinator.gateway_not_ready is False
+
+
+# --- enrichment failure isolation (#386) ---
+
+
+@pytest.mark.asyncio
+async def test_enrichment_failure_returns_raw_data(
+    coordinator, mock_api_client, caplog
+):
+    """A derived-metrics crash must not masquerade as a gateway error."""
+    mock_api_client.read_value = AsyncMock(return_value=42)
+    coordinator.derived_metrics = MagicMock()
+    coordinator.derived_metrics.update.side_effect = KeyError("boom")
+
+    with patch("custom_components.hitachi_yutaki.coordinator.ir") as mock_ir:
+        data = await coordinator._async_update_data()
+
+    assert data["is_available"] is True
+    assert data["system_state"] == 42
+    mock_ir.async_create_issue.assert_not_called()
+    mock_ir.async_delete_issue.assert_called_once_with(
+        coordinator.hass, DOMAIN, "connection_error"
+    )
+    assert "returning raw poll data" in caplog.text
+    assert "KeyError" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_refrigerant_issue_update_failure_returns_raw_data(
+    coordinator, mock_api_client
+):
+    """A crash in the refrigerant repair-issue update is not a gateway error."""
+    coordinator.derived_metrics = MagicMock()
+    with (
+        patch.object(
+            coordinator, "_update_refrigerant_issue", side_effect=ValueError("boom")
+        ),
+        patch("custom_components.hitachi_yutaki.coordinator.ir") as mock_ir,
+    ):
+        data = await coordinator._async_update_data()
+
+    assert data["is_available"] is True
+    mock_ir.async_create_issue.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_telemetry_collect_failure_returns_raw_data(coordinator):
+    """A crash in telemetry collection is not a gateway error."""
+    coordinator.telemetry_collector = MagicMock()
+    coordinator.telemetry_collector.collect.side_effect = ValueError("boom")
+
+    with patch("custom_components.hitachi_yutaki.coordinator.ir") as mock_ir:
+        data = await coordinator._async_update_data()
+
+    assert data["is_available"] is True
+    mock_ir.async_create_issue.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_modbus_read_values_failure_reports_connection_error(
+    coordinator, mock_api_client
+):
+    """A real Modbus failure keeps today's semantics: issue + UpdateFailed."""
+    mock_api_client.read_values = AsyncMock(side_effect=ConnectionError("dead link"))
+
+    with (
+        patch("custom_components.hitachi_yutaki.coordinator.ir") as mock_ir,
+        pytest.raises(UpdateFailed, match="Failed to communicate"),
+    ):
+        await coordinator._async_update_data()
+
+    mock_ir.async_create_issue.assert_called_once()
+    assert mock_ir.async_create_issue.call_args.args[2] == "connection_error"
+    mock_ir.async_delete_issue.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_modbus_mid_poll_failure_reports_connection_error(
+    coordinator, mock_api_client
+):
+    """A per-key read failure (raw poll loop) is still a gateway error."""
+    mock_api_client.read_value = AsyncMock(side_effect=OSError("read failed"))
+
+    with (
+        patch("custom_components.hitachi_yutaki.coordinator.ir") as mock_ir,
+        pytest.raises(UpdateFailed, match="Failed to communicate"),
+    ):
+        await coordinator._async_update_data()
+
+    mock_ir.async_create_issue.assert_called_once()


### PR DESCRIPTION
## Description

`_async_update_data` wrapped its entire body in a single `try` whose fallback reported a gateway communication failure. Post-fetch stages that have nothing to do with the gateway (derived-metrics enrichment, refrigerant repair-issue update, `system_config` persistence, telemetry collection) were covered too, so any `KeyError`/`ValueError` in a computation was indistinguishable from a dead RS-485 link: the user got a `connection_error` repair issue and every entity flapped unavailable, even though the poll had returned complete valid register data. We know from #356 how load-bearing the connection-vs-software distinction is in support, and the enrichment surface keeps growing.

Minimal fix, separating the failure domains:

- the outer `try` now ends right after the raw Modbus fetch; the `connection_error` delete moved up to fire as soon as the poll succeeds;
- all post-fetch stages run after it under their own guard: on failure, the error is logged with a full stack trace as an integration bug and the **raw poll data is returned**. Register-backed entities keep updating; derived sensors may read `unknown` for the affected cycles. No `connection_error` issue, no `UpdateFailed`;
- real Modbus failures keep the exact previous semantics: `connection_error` issue + `UpdateFailed` + gateway-not-ready backoff. The 7 pre-existing coordinator tests pass unmodified, which is the witness that the I/O path is untouched.

Explicitly out of scope (per the issue): per-stage error taxonomy and an enrichment-health diagnostic sensor.

### Testing

- 5 new coordinator regression tests: derived-metrics crash, refrigerant-issue-update crash and telemetry-collect crash all return raw data with no issue created; `read_values` and per-key `read_value` failures still raise `UpdateFailed` and create `connection_error`.
- Full suite: **470 passed**. `make check` clean.

## Checklist

- [x] Tests pass (`make test`)
- [x] Code quality checks pass (`make check`)
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] New/modified entities follow architecture rules (no entity change)
- [x] Documentation updated (`docs/architecture.md`, failure-attribution note in Data Flow)
- [x] Translation keys added to `translations/en.json` (n/a, no new keys)

Closes #386
