### PR TITLE
release: 2.2.0-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0-beta.3] - 2026-07-26
+
 ### Changed
 - Refrigerant charge detection (beta) is now opt-in and off by default. It lives in a new "Advanced features (beta)" panel (its first toggle) shown as the last step of setup and in the integration Options (the cog), and existing installations get a one-time onboarding notification ("Try refrigerant charge monitoring (beta)") whose fix flow enables it. The panel is only offered on profiles with the extended compressor sensors (never the Yutampo R32). The consent text strongly cautions that the feature is experimental, rests on very little validation data, and will only be considered stable after a full winter heating season: any alert is a hint to look closer, not a diagnosis (it can be a false positive), so do not call a technician or pay for a service on an alert alone, always double-check first. It also invites enabling anonymous telemetry so the detector's reliability can be validated across the fleet. The detector, its `Refrigerant Charge Status` sensor, the `Reset Refrigerant Baseline` button and the repair issue now run only when both the heat-pump profile exposes the extended compressor sensors and you have consented (#393).
 - Refrigerant charge alert: the repair issue is now fixable: confirming the circuit was serviced resets the detection baseline (same as the Reset Refrigerant Baseline button) (#384).

--- a/custom_components/hitachi_yutaki/manifest.json
+++ b/custom_components/hitachi_yutaki/manifest.json
@@ -15,5 +15,5 @@
   "requirements": [
     "pymodbus>=3.6.9,<4.0.0"
   ],
-  "version": "2.2.0-beta.2"
+  "version": "2.2.0-beta.3"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hass-hitachi-yutaki"
-version = "2.2.0-beta.2"
+version = "2.2.0-beta.3"
 requires-python = ">=3.13.2"
 description = "Home Assistant custom integration for Hitachi Yutaki heat pumps"
 license = "MIT"


### PR DESCRIPTION
## Description

Release PR for **v2.2.0-beta.3**. Bumps the version (`manifest.json` + `pyproject.toml`) and moves the `[Unreleased]` CHANGELOG entries under a dated `## [2.2.0-beta.3] - 2026-07-26` section. No code changes.

This third 2.2.0 pre-release consolidates the refrigerant charge-loss detector shipped in `beta.2`:

- **Opt-in** (off by default), presented in an *Advanced features (beta)* panel at setup, in the options, and via a one-time onboarding notification, with strong caution wording (#393 / #401).
- **Recalibrated** plausibility bounds per heat-pump profile, fixing the detector starving on Yutaki S80 / M (#393 / #394).
- **Hardened**: restore-before-first-poll and atomic restore (#383), stale end-of-season alert annotation + serviced fix flow (#384), config-entry cleanup on removal (#385), enrichment errors no longer misreported as gateway faults (#386).

The GitHub release (with the full user-facing notes) will be published as a pre-release from the `v2.2.0-beta.3` tag once this merges.

## Upgrade note (for the release)

The detector is now off by default, so it will be disabled after updating even if it ran in `beta.2`. To keep it: enable it via the notification or the integration Options (*Advanced features*), then press **Reset Refrigerant Baseline** (the recalibration biases any baseline learned under `beta.2`, notably on S80 / M). No stored-data migration is performed.

## Checklist

- [x] Version bumped in `manifest.json` and `pyproject.toml`
- [x] `CHANGELOG.md` entries moved from `[Unreleased]` to the dated section
- [x] No code changes (release-only)
