### PR TITLE
fix(worker): harden the ingestion endpoint against four archive defects

### DIFF
--- a/backend/worker/src/archive.ts
+++ b/backend/worker/src/archive.ts
@@ -3,8 +3,8 @@
  * Hive-style partitioning for DuckDB/Parquet compatibility.
  *
  * File layout:
- *   metrics/year=2026/month=03/day=13/batch_<ts>_<hash>.json
- *   snapshots/year=2026/month=03/day=13/snap_<ts>_<hash>.json
+ *   metrics/year=2026/month=03/day=13/batch_<ts>_<rand>_<hash>.json
+ *   snapshots/year=2026/month=03/day=13/snap_<ts>_<rand>_<hash>.json
  *   daily_stats/year=2026/month=03/daily_<date>_<hash>.json
  *   installations/install_<hash>.json
  *
@@ -19,7 +19,13 @@ import type {
 } from "./types";
 
 function dateParts(isoDate?: string): { year: string; month: string; day: string } {
-  const d = isoDate ? new Date(isoDate) : new Date();
+  const parsed = isoDate ? new Date(isoDate) : new Date();
+  // An unparseable date makes every component NaN, which would archive the
+  // object under `year=NaN/month=NaN/day=NaN/`: invisible to every
+  // date-partitioned scan and enough to break a typed hive-partitioned read of
+  // the whole tree. Fall back to ingestion time instead of rejecting, since the
+  // payload itself is still usable data (#414).
+  const d = Number.isNaN(parsed.getTime()) ? new Date() : parsed;
   return {
     year: String(d.getUTCFullYear()),
     month: String(d.getUTCMonth() + 1).padStart(2, "0"),
@@ -29,6 +35,24 @@ function dateParts(isoDate?: string): { year: string; month: string; day: string
 
 function shortHash(instanceHash: string): string {
   return instanceHash.slice(0, 12);
+}
+
+/**
+ * Random component for append-only object names.
+ *
+ * The timestamp alone has one-second resolution, so two batches from one
+ * instance in the same second computed the same key and the second `put`
+ * silently replaced the first. The rate limiter makes that unlikely, not
+ * impossible: the Cache API is per-colo, so two requests reaching two colos
+ * can both pass `isRateLimited` (a leak the limiter documents as acceptable,
+ * on the assumption that an extra accepted request is harmless). It is
+ * harmless only if it does not overwrite anything (#414).
+ *
+ * Placed before the hash so a name still *ends* with it, which is what the
+ * documented way of matching an object to an installation relies on.
+ */
+function nonce(): string {
+  return crypto.randomUUID().slice(0, 8);
 }
 
 /**
@@ -61,7 +85,7 @@ function buildKey(payload: TelemetryPayload): string {
     case "metrics": {
       const firstTime = (payload as MetricsPayload).points[0]?.time;
       const { year, month, day } = dateParts(firstTime);
-      return `metrics/year=${year}/month=${month}/day=${day}/batch_${ts}_${hash}.json`;
+      return `metrics/year=${year}/month=${month}/day=${day}/batch_${ts}_${nonce()}_${hash}.json`;
     }
     case "daily_stats": {
       const { year, month } = dateParts((payload as DailyStatsPayload).date);
@@ -69,7 +93,7 @@ function buildKey(payload: TelemetryPayload): string {
     }
     case "snapshot": {
       const { year, month, day } = dateParts();
-      return `snapshots/year=${year}/month=${month}/day=${day}/snap_${ts}_${hash}.json`;
+      return `snapshots/year=${year}/month=${month}/day=${day}/snap_${ts}_${nonce()}_${hash}.json`;
     }
   }
 }

--- a/backend/worker/src/index.ts
+++ b/backend/worker/src/index.ts
@@ -19,7 +19,47 @@ import {
   markRateLimit,
 } from "./rate-limiter";
 import type { Env } from "./types";
-import { ValidationError, validate } from "./validator";
+import { MAX_PAYLOAD_SIZE, ValidationError, validate } from "./validator";
+
+/**
+ * Read a stream as text, refusing anything past `limit` bytes.
+ *
+ * The size check in the validator runs on the decompressed string, so buffering
+ * the whole body first meant a small gzip payload expanding to gigabytes was
+ * materialised before anything could reject it, exhausting the isolate. The
+ * endpoint is public and unauthenticated, so the bound has to be enforced while
+ * reading, not after (#414). An oversized body still answers 413, exactly as it
+ * did when the validator was the one to catch it.
+ */
+async function readBoundedText(
+  stream: ReadableStream<Uint8Array>,
+  limit: number,
+): Promise<string> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    total += value.byteLength;
+    if (total > limit) {
+      await reader.cancel().catch(() => undefined);
+      throw new ValidationError("Payload too large", 413);
+    }
+    chunks.push(value);
+  }
+
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(merged);
+}
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
@@ -33,14 +73,14 @@ export default {
     }
 
     try {
-      // Decompress if gzipped, otherwise read as text
-      let body: string;
-      if (request.headers.get("content-encoding") === "gzip") {
-        const ds = new DecompressionStream("gzip");
-        const decompressed = request.body!.pipeThrough(ds);
-        body = await new Response(decompressed).text();
-      } else {
-        body = await request.text();
+      // Decompress if gzipped, otherwise read as text. Bounded either way.
+      let body = "";
+      if (request.body) {
+        const stream =
+          request.headers.get("content-encoding") === "gzip"
+            ? request.body.pipeThrough(new DecompressionStream("gzip"))
+            : request.body;
+        body = await readBoundedText(stream, MAX_PAYLOAD_SIZE);
       }
 
       // Validate and sanitize

--- a/backend/worker/src/validator.ts
+++ b/backend/worker/src/validator.ts
@@ -13,24 +13,34 @@ import type {
 } from "./types";
 
 const INSTANCE_HASH_RE = /^[a-f0-9]{64}$/;
-const MAX_PAYLOAD_SIZE = 256 * 1024; // 256 KB uncompressed
+/** Decompressed body limit. Exported so the request reader enforces it too. */
+export const MAX_PAYLOAD_SIZE = 256 * 1024; // 256 KB uncompressed
 const MAX_METRICS_POINTS = 500;
 
-/** Allowed installation data fields (whitelist). */
-const INSTALLATION_FIELDS = new Set([
-  "profile",
-  "gateway_type",
-  "ha_version",
-  "integration_version",
-  "power_supply",
-  "has_dhw",
-  "has_pool",
-  "has_cooling",
-  "max_circuits",
-  "has_secondary_compressor",
-  "latitude",
-  "longitude",
-  "climate_zone",
+/**
+ * Allowed installation data fields, with the type each one must have.
+ *
+ * The whitelist used to copy values verbatim, so a field of the wrong type was
+ * archived as-is and then threw inside the Analytics Engine write, whose catch
+ * is deliberately silent: the installation existed in R2 but never reached the
+ * fleet dashboard, with nothing to show for it (#414). A field of the wrong
+ * type is now dropped rather than rejected, so a client sending one keeps
+ * having the rest of its payload accepted.
+ */
+const INSTALLATION_FIELDS = new Map<string, "string" | "number" | "boolean">([
+  ["profile", "string"],
+  ["gateway_type", "string"],
+  ["ha_version", "string"],
+  ["integration_version", "string"],
+  ["power_supply", "string"],
+  ["has_dhw", "boolean"],
+  ["has_pool", "boolean"],
+  ["has_cooling", "boolean"],
+  ["max_circuits", "number"],
+  ["has_secondary_compressor", "boolean"],
+  ["latitude", "number"],
+  ["longitude", "number"],
+  ["climate_zone", "string"],
 ]);
 
 /** Allowed daily stats data fields (whitelist). */
@@ -72,6 +82,30 @@ function whitelist(
     if (key in obj) {
       result[key] = obj[key];
     }
+  }
+  return result;
+}
+
+/** Whitelist that also drops any field whose value is not of the given type. */
+function typedWhitelist(
+  obj: Record<string, unknown>,
+  allowed: Map<string, "string" | "number" | "boolean">,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, expected] of allowed) {
+    if (!(key in obj)) {
+      continue;
+    }
+    const value = obj[key];
+    if (typeof value !== expected) {
+      console.warn(`dropped ${key}: expected ${expected}, got ${typeof value}`);
+      continue;
+    }
+    if (expected === "number" && !Number.isFinite(value)) {
+      console.warn(`dropped ${key}: not a finite number`);
+      continue;
+    }
+    result[key] = value;
   }
   return result;
 }
@@ -141,7 +175,7 @@ function validateInstallation(
   return {
     type: "installation",
     instance_hash: instanceHash,
-    data: whitelist(d, INSTALLATION_FIELDS) as InstallationPayload["data"],
+    data: typedWhitelist(d, INSTALLATION_FIELDS) as InstallationPayload["data"],
   };
 }
 

--- a/backend/worker/test/index.test.ts
+++ b/backend/worker/test/index.test.ts
@@ -108,3 +108,261 @@ describe("fetch handler — rate limit + archive (#324)", () => {
     expect(bucket.put).not.toHaveBeenCalled();
   });
 });
+
+/** Hands back the AE fake so its writes can be asserted. */
+function makeEnvWithAE(bucket: ReturnType<typeof createFakeBucket>) {
+  const ae = createFakeAE();
+  const env = {
+    ARCHIVE: bucket as unknown as R2Bucket,
+    AE: ae as unknown as AnalyticsEngineDataset,
+  } satisfies Env;
+  return { env, ae };
+}
+
+function installationPayload(data: Record<string, unknown> = {}) {
+  return {
+    type: "installation",
+    instance_hash: HASH,
+    data: {
+      profile: "yutaki_s80",
+      gateway_type: "modbus_atw_mbs_02",
+      ha_version: "2026.8.0",
+      integration_version: "2.2.0",
+      power_supply: "single",
+      has_dhw: true,
+      has_pool: false,
+      has_cooling: true,
+      max_circuits: 2,
+      has_secondary_compressor: true,
+      latitude: 48.5,
+      longitude: 2.5,
+      ...data,
+    },
+  };
+}
+
+/** The key the bucket was asked to write, from the first `put` call. */
+function writtenKey(bucket: ReturnType<typeof createFakeBucket>): string {
+  return bucket.put.mock.calls[0][0] as unknown as string;
+}
+
+describe("hardening (#414)", () => {
+  describe("a batch is never archived under a NaN partition", () => {
+    it("falls back to ingestion time when the first point's time is unparseable", async () => {
+      const bucket = createFakeBucket();
+      const payload = {
+        ...metricsPayload(),
+        points: [{ time: "not-a-date", outdoor_temp: 5 }],
+      };
+
+      const res = await worker.fetch(makeRequest(payload), makeEnv(bucket));
+
+      // Accepted, because the payload itself is usable data.
+      expect(res.status).toBe(202);
+      expect(writtenKey(bucket)).not.toContain("NaN");
+      expect(writtenKey(bucket)).toMatch(
+        /^metrics\/year=\d{4}\/month=\d{2}\/day=\d{2}\//,
+      );
+    });
+
+    it("still partitions on the point's own date when it is valid", async () => {
+      const bucket = createFakeBucket();
+
+      await worker.fetch(makeRequest(metricsPayload()), makeEnv(bucket));
+
+      expect(writtenKey(bucket)).toContain("metrics/year=2026/month=03/day=13/");
+    });
+  });
+
+  describe("an oversized body is refused while reading, not after", () => {
+    it("answers 413 on a body past the limit", async () => {
+      const bucket = createFakeBucket();
+      const payload = {
+        ...metricsPayload(),
+        points: [{ time: "2026-03-13T12:00:00Z", blob: "x".repeat(300 * 1024) }],
+      };
+
+      const res = await worker.fetch(makeRequest(payload), makeEnv(bucket));
+
+      expect(res.status).toBe(413);
+      expect(bucket.put).not.toHaveBeenCalled();
+    });
+
+    it("stops pulling from the stream instead of buffering it whole", async () => {
+      // The point of the fix: a small gzip payload expanding to gigabytes must
+      // not be materialised before anything rejects it. Counting how much of
+      // the body the Worker actually pulls is what separates "refused while
+      // reading" from "refused after buffering", which a status assertion
+      // alone cannot tell apart.
+      const CHUNK = 64 * 1024;
+      let pulled = 0;
+      const endless = new ReadableStream<Uint8Array>({
+        pull(controller) {
+          pulled += CHUNK;
+          if (pulled > 64 * 1024 * 1024) {
+            controller.close();
+            return;
+          }
+          controller.enqueue(new Uint8Array(CHUNK).fill(120));
+        },
+      });
+      const request = new Request("https://telemetry.internal/v1/ingest", {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-instance-hash": HASH },
+        body: endless,
+        duplex: "half",
+      } as RequestInit);
+
+      const res = await worker.fetch(request, makeEnv(createFakeBucket()));
+
+      expect(res.status).toBe(413);
+      // A handful of chunks past the 256 KB limit, not 64 MB of them.
+      expect(pulled).toBeLessThan(1024 * 1024);
+    });
+
+    it("accepts a body just under the limit", async () => {
+      const bucket = createFakeBucket();
+      const payload = {
+        ...metricsPayload(),
+        points: [{ time: "2026-03-13T12:00:00Z", blob: "x".repeat(200 * 1024) }],
+      };
+
+      const res = await worker.fetch(makeRequest(payload), makeEnv(bucket));
+
+      expect(res.status).toBe(202);
+    });
+  });
+
+  describe("installation fields of the wrong type are dropped, not archived", () => {
+    it("drops a non-numeric latitude and still accepts the payload", async () => {
+      const bucket = createFakeBucket();
+
+      const res = await worker.fetch(
+        makeRequest(installationPayload({ latitude: "fifty" })),
+        makeEnv(bucket),
+      );
+
+      expect(res.status).toBe(202);
+      const archived = JSON.parse(bucket.put.mock.calls[0][1] as unknown as string);
+      expect(archived.data.latitude).toBeUndefined();
+      expect(archived.data.profile).toBe("yutaki_s80");
+    });
+
+    it("keeps the Analytics Engine write alive when a field is malformed", async () => {
+      // The AE catch is silent by design, so a throw there means an install
+      // that exists in R2 and nowhere on the dashboard.
+      const bucket = createFakeBucket();
+      const { env, ae } = makeEnvWithAE(bucket);
+
+      await worker.fetch(
+        makeRequest(installationPayload({ max_circuits: "two" })),
+        env,
+      );
+
+      expect(ae.writeDataPoint).toHaveBeenCalledTimes(1);
+      const written = ae.writeDataPoint.mock.calls[0][0];
+      expect(written.doubles.every((d: unknown) => typeof d === "number")).toBe(true);
+    });
+
+    it("drops a NaN where a number is expected", async () => {
+      const bucket = createFakeBucket();
+
+      await worker.fetch(
+        makeRequest(installationPayload({ longitude: Number.NaN })),
+        makeEnv(bucket),
+      );
+
+      const archived = JSON.parse(bucket.put.mock.calls[0][1] as unknown as string);
+      expect(archived.data.longitude).toBeUndefined();
+    });
+  });
+
+  describe("two batches in the same second no longer overwrite each other", () => {
+    it("gives two identical payloads two distinct object names", async () => {
+      const first = createFakeBucket();
+      const second = createFakeBucket();
+
+      await worker.fetch(makeRequest(metricsPayload()), makeEnv(first));
+      // A second colo would not see the first request's rate-limit marker.
+      fakeCache.store.clear();
+      await worker.fetch(makeRequest(metricsPayload()), makeEnv(second));
+
+      expect(writtenKey(first)).not.toBe(writtenKey(second));
+    });
+
+    it("keeps the instance hash at the end of the name", async () => {
+      // Matching an object to an installation is documented as an ends-with on
+      // the 12-char hash, so the random component goes before it.
+      const bucket = createFakeBucket();
+
+      await worker.fetch(makeRequest(metricsPayload()), makeEnv(bucket));
+
+      expect(writtenKey(bucket).endsWith(`_${HASH.slice(0, 12)}.json`)).toBe(true);
+    });
+
+    it("leaves the installation object name stable", async () => {
+      // That one is a current-state document: overwriting it is the point.
+      const bucket = createFakeBucket();
+
+      await worker.fetch(makeRequest(installationPayload()), makeEnv(bucket));
+
+      expect(writtenKey(bucket)).toBe(`installations/install_${HASH.slice(0, 12)}.json`);
+    });
+  });
+
+  describe("clients in the field keep working unchanged", () => {
+    it("accepts the exact payload shape the released integration sends", async () => {
+      const bucket = createFakeBucket();
+      const { env, ae } = makeEnvWithAE(bucket);
+
+      const install = await worker.fetch(makeRequest(installationPayload()), env);
+      fakeCache.store.clear();
+      const metrics = await worker.fetch(makeRequest(metricsPayload()), makeEnv(bucket));
+
+      expect(install.status).toBe(202);
+      expect(metrics.status).toBe(202);
+      expect(ae.writeDataPoint).toHaveBeenCalledTimes(1);
+      const archived = JSON.parse(bucket.put.mock.calls[0][1] as unknown as string);
+      expect(archived.data).toMatchObject({
+        profile: "yutaki_s80",
+        gateway_type: "modbus_atw_mbs_02",
+        latitude: 48.5,
+        longitude: 2.5,
+        max_circuits: 2,
+        has_dhw: true,
+      });
+    });
+
+    it("accepts a gzipped body, which is how the integration sends", async () => {
+      const bucket = createFakeBucket();
+      const json = JSON.stringify(metricsPayload());
+      const gzipped = new Response(
+        new Blob([json]).stream().pipeThrough(new CompressionStream("gzip")),
+      );
+      const request = new Request("https://telemetry.internal/v1/ingest", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "content-encoding": "gzip",
+          "x-instance-hash": HASH,
+        },
+        body: await gzipped.arrayBuffer(),
+      });
+
+      const res = await worker.fetch(request, makeEnv(bucket));
+
+      expect(res.status).toBe(202);
+    });
+
+    it("still omits an absent optional field rather than inventing one", async () => {
+      const bucket = createFakeBucket();
+      const payload = installationPayload();
+      delete (payload.data as Record<string, unknown>).latitude;
+
+      await worker.fetch(makeRequest(payload), makeEnv(bucket));
+
+      const archived = JSON.parse(bucket.put.mock.calls[0][1] as unknown as string);
+      expect("latitude" in archived.data).toBe(false);
+    });
+  });
+});

--- a/docs/development/telemetry-dataset.md
+++ b/docs/development/telemetry-dataset.md
@@ -14,12 +14,13 @@ Payloads are stored as individual JSON files, Hive-partitioned by date (`backend
 
 ```
 installations/install_<hash12>.json
-snapshots/year=YYYY/month=MM/day=DD/snap_<ts>_<hash12>.json
-metrics/year=YYYY/month=MM/day=DD/batch_<ts>_<hash12>.json
+snapshots/year=YYYY/month=MM/day=DD/snap_<ts>_<rand>_<hash12>.json
+metrics/year=YYYY/month=MM/day=DD/batch_<ts>_<rand>_<hash12>.json
 daily_stats/year=YYYY/month=MM/daily_<date>_<hash12>.json
 ```
 
-- `<hash12>` = first 12 chars of the SHA-256 instance hash.
+- `<hash12>` = first 12 chars of the SHA-256 instance hash. It is always the last component of the name, so matching an object to an installation stays an ends-with on that hash.
+- `<rand>` = 8 random hex characters. The timestamp has one-second resolution, so without it two batches from one instance in the same second landed on the same key and the second write replaced the first. Objects written before this was added have no `<rand>` component, which changes nothing for a match on the hash.
 - **installations** carry `data.profile` (e.g. `yutampo_r32`, `yutaki_s`, `yutaki_s80`), `gateway_type`, `has_dhw/pool/cooling`, `max_circuits`.
 - **snapshots** carry a one-time `registers` dict (numeric register values incl. `system_config`): the raw material for fixtures.
 


### PR DESCRIPTION
## Description

Closes the four items of #414 that are reachable on `main` today. None of them is a regression from #411: they predate it, so they are fixed here, ahead of it and independently of it, and the Worker can be deployed before that PR lands.

The fifth item in #414, a `device_hash` sent as `null` being rejected with a permanent 400, only exists once #411 introduces `device_hash` on the Worker. It belongs in that PR, not here.

### :bricks: What changed

**A batch could be archived under a `NaN` partition.** `validator.ts` checked only that `point.time` was a string, and `archive.ts` fed it straight to `new Date()`. An unparseable value made every component `NaN`, so the object landed in `metrics/year=NaN/month=NaN/day=NaN/` with a 202: invisible to every date-partitioned scan, and enough to break a typed hive-partitioned read of the whole tree. The date now falls back to ingestion time. Rejecting was the other option, but the payload itself is usable data and a client already in the field cannot be fixed retroactively.

**A decompression bomb could exhaust the isolate.** The decompressed body was buffered whole before the size check ran on it, so a small gzip payload expanding to gigabytes was materialised before anything could reject it. On a public unauthenticated endpoint that is a way to take ingestion down. The body is read with a running byte cap now, and an oversized one still answers 413, exactly as when the validator was the one to catch it.

**A malformed installation field killed the dashboard row, silently.** Whitelisted fields were copied without checking their type, so `latitude: "fifty"` was archived verbatim and then threw inside the Analytics Engine write, whose catch is deliberately silent. The installation existed in R2 and never appeared on the fleet dashboard, with nothing logged beyond a `console.warn`. A field of the wrong type is now dropped and logged rather than rejected, so a client sending one keeps having the rest of its payload accepted.

**Two batches in the same second overwrote each other.** The object name had one-second resolution, so two requests from one instance in the same second computed the same key and the second `put` replaced the first. The rate limiter makes that unlikely, not impossible: the Cache API is per-colo, and the limiter itself documents that leak as acceptable on the assumption an extra accepted request is harmless. It is harmless only if it overwrites nothing. Metrics and snapshot names gain a random component, **placed before the hash** so a name still ends with it and the documented way of matching an object to an installation is unchanged. The installation object name is left alone: it is a current-state document and overwriting it is the point.

### :handshake: Backward compatibility

Every client in the field is a released version, so the binding constraint is that no payload accepted before is refused now. That is tested directly rather than argued:

- the exact payload shape the released integration sends, installation and metrics, still gets a 202 and still reaches Analytics Engine;
- the gzipped body, which is how the integration actually sends;
- an absent optional field stays absent rather than being invented;
- a body under the limit is still accepted, and one over it still answers 413 rather than some new status.

Object names change shape for metrics and snapshots. Nothing reads them positionally: `backend/analysis/pull_day.sh` globs `batch_*.json`, and the documented match is an ends-with on the hash, which still holds. Objects written before this change have no random component, which changes nothing for that match. `docs/development/telemetry-dataset.md` is updated.

### :microscope: Verification

Worker suite 6 to 20 tests. Each fix was checked by mutation: reverting it makes the matching test fail.

One of those took two attempts worth mentioning. The first version of the oversized-body test asserted only the 413, which passes whether the body is refused while reading or after being buffered whole, since the validator catches the size either way. It therefore pinned nothing about the actual fix. It now counts how much of the body the Worker pulls and asserts it stops a few chunks past the limit rather than reading 64 MB.

## Checklist

- [x] Tests pass (`npm test` in `backend/worker`)
- [x] Code quality checks pass (`make check`)
- [ ] `CHANGELOG.md` updated under `[Unreleased]` (backend only, no effect on an integration release, `skip-changelog`)
- [x] New/modified entities follow [architecture rules](docs/architecture.md)
- [x] Documentation updated for any behavior/architecture/register/entity/workflow change
- [ ] Translation keys added to `translations/en.json` (not applicable)

Refs #414

https://claude.ai/code/session_01NtnPkzmrbFvS47641Mhwgd