### PR TITLE
chore: make the Worker deploy name its target account

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -110,7 +110,7 @@ Domain logic goes in `domain/services/`, adapter logic in `adapters/`. See [docs
 - **Backend side**: Cloudflare Worker in `backend/worker/src/`.
 - Fields must match across Python models (`to_dict()`) and the Worker validator (field whitelists).
 - Telemetry entities read from coordinator attributes (not `coordinator.data`).
-- Deploy Worker changes with `cd backend/worker && npx wrangler deploy`.
+- Deploy Worker changes with `make worker-deploy`, which runs the Worker suite first and refuses to deploy unless `CLOUDFLARE_ACCOUNT_ID` names the target account (set it in the gitignored `backend/worker/.env`). Calling `npx wrangler deploy` directly risks deploying to whichever account the local OAuth token belongs to.
 
 ### Entity Migration
 - `entity_migration.py` handles `unique_id` migrations; it runs automatically during integration setup.

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,47 @@ bump: ## Bump version — usage: make bump [PART=patch|minor|major|beta] (defaul
 version: ## Show current version
 	@echo $(VERSION)
 
+# —— Telemetry backend ——————————————————————————————————
+
+WORKER_DIR := backend/worker
+
+# Load the Worker's local .env (gitignored) so make sees the same account
+# wrangler would read from it. A missing file is fine: the guard below is what
+# reports it, with an actionable message.
+-include $(WORKER_DIR)/.env
+export CLOUDFLARE_ACCOUNT_ID
+
+# Refuse to act without an explicit account. wrangler otherwise falls back to
+# whichever account the local OAuth token happens to belong to, which silently
+# deploys the Worker somewhere else and auto-provisions an empty R2 bucket
+# there instead of failing.
+define require_cf_account
+	@test -n "$(CLOUDFLARE_ACCOUNT_ID)" || { \
+		echo "CLOUDFLARE_ACCOUNT_ID is not set."; \
+		echo "Put 'CLOUDFLARE_ACCOUNT_ID=<id>' in $(WORKER_DIR)/.env (gitignored),"; \
+		echo "or export it. Find the id at dash.cloudflare.com/<account_id>."; \
+		exit 1; \
+	}
+endef
+
+.PHONY: worker-install
+worker-install: ## Install the telemetry Worker's dependencies
+	cd $(WORKER_DIR) && npm ci
+
+.PHONY: worker-test
+worker-test: ## Run the telemetry Worker test suite
+	cd $(WORKER_DIR) && npm test
+
+.PHONY: worker-deploy
+worker-deploy: ## Deploy the telemetry Worker (requires CLOUDFLARE_ACCOUNT_ID)
+	$(require_cf_account)
+	cd $(WORKER_DIR) && npm test && npx wrangler deploy
+
+.PHONY: worker-deploy-dry
+worker-deploy-dry: ## Build the Worker without deploying (requires CLOUDFLARE_ACCOUNT_ID)
+	$(require_cf_account)
+	cd $(WORKER_DIR) && npx wrangler deploy --dry-run
+
 # —— Diagnostics ———————————————————————————————————————
 
 .PHONY: scan

--- a/backend/README.md
+++ b/backend/README.md
@@ -91,10 +91,22 @@ npx wrangler dev    # Runs locally with bindings
 ### Deploy
 
 ```bash
-cd backend/worker
-npx wrangler login  # One-time OAuth (opens browser)
-npx wrangler deploy
+npx wrangler login          # One-time OAuth (opens browser)
+echo "CLOUDFLARE_ACCOUNT_ID=<id>" > backend/worker/.env   # one-time, gitignored
+make worker-deploy          # runs the test suite, then deploys
 ```
+
+**Always name the account.** Without `CLOUDFLARE_ACCOUNT_ID`, wrangler targets
+whichever account the local OAuth token happens to belong to. If that is not
+the account hosting this Worker, the deploy does not fail: it creates a second
+Worker there and auto-provisions an empty R2 bucket to satisfy the binding,
+while the real endpoint keeps serving the old code. `make worker-deploy`
+refuses to run rather than let that happen, and `backend/worker/.env` is
+gitignored so the id stays out of this public repository. Find the id in the
+dashboard URL, `dash.cloudflare.com/<account_id>`.
+
+`make worker-deploy-dry` builds without deploying, `make worker-test` runs the
+suite alone.
 
 ### TypeScript structure
 
@@ -141,8 +153,8 @@ Or use Cloudflare MCP tools (`accounts_list`, `r2_bucket_create`).
 ### 2. Deploy Worker
 
 ```bash
-cd backend/worker
-npm install
+make worker-install
 npx wrangler login
-npx wrangler deploy
+echo "CLOUDFLARE_ACCOUNT_ID=<id>" > backend/worker/.env
+make worker-deploy
 ```


### PR DESCRIPTION
## Description

`wrangler` resolves the Cloudflare account from whichever OAuth token is logged in locally, and `wrangler.toml` pins none.

On a machine logged into a different account than the one hosting this Worker, `npx wrangler deploy` **does not fail**. It creates a second Worker there, auto-provisions an empty R2 bucket to satisfy the `ARCHIVE` binding, prints a success line and a `*.workers.dev` URL, while the real endpoint keeps serving the old code. Nothing in the output says the account is wrong, and `--dry-run` does not either: it reports bindings and upload size, never the destination.

That happened while deploying #416 :sweat_smile: No production impact, since clients post to a different hostname and the stray resources have been deleted, but the deploy reported success and the hardening was not live.

### :bricks: What changed

`make worker-deploy` refuses to run unless `CLOUDFLARE_ACCOUNT_ID` names the account, and runs the Worker suite before deploying:

```
$ make worker-deploy
CLOUDFLARE_ACCOUNT_ID is not set.
Put 'CLOUDFLARE_ACCOUNT_ID=<id>' in backend/worker/.env (gitignored),
or export it. Find the id at dash.cloudflare.com/<account_id>.
make: *** [worker-deploy] Error 1
```

The variable is read from `backend/worker/.env`, which the Makefile includes and wrangler loads on its own, so one gitignored file configures both. Setting it also changes the failure mode where it counts: with the account named, a deploy from the wrong login gets a permission error from the API instead of quietly succeeding elsewhere.

`worker-install`, `worker-test` and `worker-deploy-dry` come with it. There were no make targets for the backend at all, so the documented way to deploy was a command typed from memory.

### :thinking_face: The alternative, and why not

Pinning `account_id` in `wrangler.toml` does the same job with no local setup and no way to forget it. It also publishes the account id in a public repository. This keeps the id private and makes the missing-configuration case loud rather than silent, which was the actual defect. Worth revisiting if the local-setup step proves annoying.

### :mag: Verification

The guard was exercised in all three configurations:

| Setup | Result |
|---|---|
| No `.env`, no env var | refuses, exit code 2, actionable message |
| `backend/worker/.env` present | proceeds, and the API call targets that account |
| Shell env var only | proceeds |

That the account actually reaches wrangler was checked separately: with a deliberately bogus id, a read-only `wrangler r2 bucket list` calls `/accounts/<bogus>/...`, both when the id comes from `.env` and when it is inline. `backend/worker/.env` is already covered by the root `.gitignore`.

Docs updated: `backend/README.md` (both the deploy and the provisioning sections) and the telemetry note in `AGENT.md`.

## Checklist

- [x] Tests pass (`make test`, `make worker-test`)
- [x] Code quality checks pass (`make check`)
- [ ] `CHANGELOG.md` updated under `[Unreleased]` (tooling only, no user-facing effect, `skip-changelog`)
- [x] New/modified entities follow [architecture rules](docs/architecture.md)
- [x] Documentation updated for any behavior/architecture/register/entity/workflow change
- [ ] Translation keys added to `translations/en.json` (not applicable)

https://claude.ai/code/session_01NtnPkzmrbFvS47641Mhwgd