### PR TITLE
fix(worker): close three ways around the deploy guard, then cover what the audit found undefended

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,10 +85,19 @@ version: ## Show current version
 
 WORKER_DIR := backend/worker
 
-# Load the Worker's local .env (gitignored) so make sees the same account
-# wrangler would read from it. A missing file is fine: the guard below is what
-# reports it, with an actionable message.
--include $(WORKER_DIR)/.env
+# Read the account id out of the Worker's local .env (gitignored), which is
+# also where wrangler reads it, so one file configures both.
+#
+# Deliberately not `-include`: that parses the whole file into make's own
+# namespace, so one line make cannot parse breaks *every* target in this
+# repository, and any assignment silently overrides a Makefile variable. This
+# extracts the single value instead, tolerating quotes, surrounding blanks and
+# CRLF. `?=` leaves an already-exported environment value untouched.
+CLOUDFLARE_ACCOUNT_ID ?= $(strip $(shell \
+	test -f $(WORKER_DIR)/.env && \
+	sed -n 's/^[[:space:]]*\(export[[:space:]][[:space:]]*\)\{0,1\}CLOUDFLARE_ACCOUNT_ID[[:space:]]*=[[:space:]]*//p' \
+		$(WORKER_DIR)/.env | tail -1 | tr -d '"'"'"'\r' \
+))
 export CLOUDFLARE_ACCOUNT_ID
 
 # Refuse to act without an explicit account. wrangler otherwise falls back to

--- a/backend/README.md
+++ b/backend/README.md
@@ -106,7 +106,11 @@ gitignored so the id stays out of this public repository. Find the id in the
 dashboard URL, `dash.cloudflare.com/<account_id>`.
 
 `make worker-deploy-dry` builds without deploying, `make worker-test` runs the
-suite alone.
+suite alone, `npm run test:watch` inside `backend/worker` watches.
+
+The provisioning commands below create resources, so name the account for them
+too: `CLOUDFLARE_ACCOUNT_ID=<id> npx wrangler r2 bucket create …`. An unnamed
+account is how an empty bucket ends up in the wrong place.
 
 ### TypeScript structure
 
@@ -144,8 +148,9 @@ If you need to recreate the infrastructure:
 ### 1. Cloudflare resources
 
 ```bash
-# R2 bucket for the archive
-npx wrangler r2 bucket create hitachi-telemetry-archive
+# R2 bucket for the archive. Name the account: wrangler otherwise picks
+# whichever one the local OAuth token belongs to.
+CLOUDFLARE_ACCOUNT_ID=<id> npx wrangler r2 bucket create hitachi-telemetry-archive
 ```
 
 Or use Cloudflare MCP tools (`accounts_list`, `r2_bucket_create`).

--- a/backend/README.md
+++ b/backend/README.md
@@ -108,6 +108,27 @@ dashboard URL, `dash.cloudflare.com/<account_id>`.
 `make worker-deploy-dry` builds without deploying, `make worker-test` runs the
 suite alone, `npm run test:watch` inside `backend/worker` watches.
 
+**What the guard does not check.** It verifies that an account id is *present*,
+never that it is the *right* one. A `CLOUDFLARE_ACCOUNT_ID` left over in your
+shell from another Cloudflare project satisfies it, and the deploy lands there
+exactly as it would have with no guard at all. The case the guard exists for is
+the one that happened, no account configured; the misinformed case stays on the
+human. If that ever stops being good enough, pin the identity itself: commit
+`account_id` to `wrangler.toml`, or assert the account name from
+`wrangler whoami` before deploying.
+
+### Payload size limit
+
+The endpoint refuses a decompressed body over **256 KB with HTTP 413**, and the
+bound that actually applies is measured in **bytes**, while reading, so a body
+that expands past it is abandoned rather than buffered. `validator.ts` also
+checks the decoded string's length; that check is a second gate, and it counts
+UTF-16 code units, so for non-ASCII content it is looser than the byte bound.
+The byte bound is the contract: it is the one that protects the isolate.
+
+The Home Assistant client caps a metrics batch at 180 KB of serialized body
+before compressing, so it stays clear of this on every heat-pump profile.
+
 The provisioning commands below create resources, so name the account for them
 too: `CLOUDFLARE_ACCOUNT_ID=<id> npx wrangler r2 bucket create …`. An unnamed
 account is how an empty bucket ends up in the wrong place.

--- a/backend/worker/package.json
+++ b/backend/worker/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "wrangler dev",
-    "deploy": "wrangler deploy",
-    "test": "vitest"
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250313.0",

--- a/backend/worker/test/index.test.ts
+++ b/backend/worker/test/index.test.ts
@@ -264,7 +264,9 @@ describe("hardening (#414)", () => {
       expect(written.doubles.every((d: unknown) => typeof d === "number")).toBe(true);
     });
 
-    it("drops a NaN where a number is expected", async () => {
+    it("drops a null where a number is expected", async () => {
+      // Named for what it does: `JSON.stringify(Number.NaN)` emits `null`, so
+      // this exercises the `typeof` branch, not the finite-number one.
       const bucket = createFakeBucket();
 
       await worker.fetch(
@@ -274,6 +276,30 @@ describe("hardening (#414)", () => {
 
       const archived = JSON.parse(bucket.put.mock.calls[0][1] as unknown as string);
       expect(archived.data.longitude).toBeUndefined();
+    });
+
+    it("drops a number that overflowed to Infinity", async () => {
+      // The finite-number guard is reachable over HTTP even though the JSON
+      // grammar has no `Infinity` literal: an exponent that overflows parses
+      // to it. `JSON.parse('{"latitude": 1e999}').latitude === Infinity`, a
+      // number, so only the isFinite check stops it reaching the archive and
+      // the Analytics Engine doubles.
+      const bucket = createFakeBucket();
+      const body = String.raw`{"type":"installation","instance_hash":"${HASH}",` +
+        String.raw`"data":{"profile":"yutaki_s80","gateway_type":"modbus_atw_mbs_02",` +
+        String.raw`"latitude":1e999,"max_circuits":2}}`;
+      const request = new Request("https://telemetry.internal/v1/ingest", {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-instance-hash": HASH },
+        body,
+      });
+
+      const res = await worker.fetch(request, makeEnv(bucket));
+
+      expect(res.status).toBe(202);
+      const archived = JSON.parse(bucket.put.mock.calls[0][1] as unknown as string);
+      expect(archived.data.latitude).toBeUndefined();
+      expect(archived.data.max_circuits).toBe(2);
     });
   });
 

--- a/backend/worker/test/index.test.ts
+++ b/backend/worker/test/index.test.ts
@@ -30,9 +30,15 @@ function createFakeBucket(opts: { fail?: boolean } = {}) {
   };
 }
 
-/** Fake Analytics Engine dataset. */
-function createFakeAE() {
-  return { writeDataPoint: vi.fn() };
+/** Fake Analytics Engine dataset; `fail` makes the write throw. */
+function createFakeAE(opts: { fail?: boolean } = {}) {
+  return {
+    writeDataPoint: vi.fn(() => {
+      if (opts.fail) {
+        throw new Error("AE unavailable");
+      }
+    }),
+  };
 }
 
 const HASH = "b".repeat(64);
@@ -110,8 +116,11 @@ describe("fetch handler — rate limit + archive (#324)", () => {
 });
 
 /** Hands back the AE fake so its writes can be asserted. */
-function makeEnvWithAE(bucket: ReturnType<typeof createFakeBucket>) {
-  const ae = createFakeAE();
+function makeEnvWithAE(
+  bucket: ReturnType<typeof createFakeBucket>,
+  aeOpts: { fail?: boolean } = {},
+) {
+  const ae = createFakeAE(aeOpts);
   const env = {
     ARCHIVE: bucket as unknown as R2Bucket,
     AE: ae as unknown as AnalyticsEngineDataset,
@@ -390,5 +399,333 @@ describe("hardening (#414)", () => {
       const archived = JSON.parse(bucket.put.mock.calls[0][1] as unknown as string);
       expect("latitude" in archived.data).toBe(false);
     });
+  });
+});
+
+describe("Analytics Engine layout — the contract with the Grafana dashboard", () => {
+  // Blobs and doubles are positional and the dashboard is not versioned in this
+  // repo, so a swap here silently corrupts every panel and cannot be repaired
+  // retroactively: the rows are already written. These assertions mirror the
+  // base query documented in backend/README.md, position by position.
+  it("emits every blob at the position the dashboard reads", async () => {
+    const { env, ae } = makeEnvWithAE(createFakeBucket());
+
+    await worker.fetch(
+      makeRequest(
+        installationPayload({ climate_zone: undefined, latitude: 48.5, longitude: 2.5 }),
+      ),
+      env,
+    );
+
+    const [point] = ae.writeDataPoint.mock.calls[0];
+    expect(point.indexes).toEqual([HASH]);
+    expect(point.blobs[0]).toBe(HASH); // blob1 instance_hash
+    expect(point.blobs[1]).toBe("yutaki_s80"); // blob2 profile
+    expect(point.blobs[2]).toBe("modbus_atw_mbs_02"); // blob3 gateway_type
+    expect(point.blobs[3]).toBe("single"); // blob4 power_supply
+    expect(point.blobs[4]).toBe("2.2.0"); // blob5 integration_version
+    expect(point.blobs[5]).toBe("2026.8.0"); // blob6 ha_version
+    expect(point.blobs[6]).toBe("Cfb"); // blob7 climate_zone, enriched worker-side
+  });
+
+  it("emits every double at the position the dashboard reads", async () => {
+    const { env, ae } = makeEnvWithAE(createFakeBucket());
+
+    await worker.fetch(makeRequest(installationPayload()), env);
+
+    const [point] = ae.writeDataPoint.mock.calls[0];
+    expect(point.doubles[0]).toBe(1); // double1 has_dhw
+    expect(point.doubles[1]).toBe(0); // double2 has_pool
+    expect(point.doubles[2]).toBe(1); // double3 has_cooling
+    expect(point.doubles[3]).toBe(1); // double4 has_secondary_compressor
+    expect(point.doubles[4]).toBe(2); // double5 max_circuits
+    expect(point.doubles[5]).toBe(48.5); // double6 latitude
+    expect(point.doubles[6]).toBe(2.5); // double7 longitude
+    expect(point.doubles).toHaveLength(7);
+  });
+
+  it("substitutes rather than shifts when an optional field is missing", async () => {
+    // A missing value must not move the ones after it.
+    const bucket = createFakeBucket();
+    const { env, ae } = makeEnvWithAE(bucket);
+    const payload = installationPayload();
+    for (const key of ["power_supply", "integration_version", "ha_version"]) {
+      delete (payload.data as Record<string, unknown>)[key];
+    }
+    delete (payload.data as Record<string, unknown>).latitude;
+    delete (payload.data as Record<string, unknown>).longitude;
+
+    await worker.fetch(makeRequest(payload), env);
+
+    const [point] = ae.writeDataPoint.mock.calls[0];
+    expect(point.blobs[3]).toBe("");
+    expect(point.blobs[4]).toBe("");
+    expect(point.blobs[5]).toBe("");
+    expect(point.blobs[6]).toBe(""); // no coordinates, so no climate zone
+    expect(point.doubles[4]).toBe(2); // max_circuits still at its position
+    expect(point.doubles[5]).toBe(0);
+    expect(point.doubles[6]).toBe(0);
+  });
+
+  it("enriches the climate zone from the coordinates", async () => {
+    const { env, ae } = makeEnvWithAE(createFakeBucket());
+
+    await worker.fetch(
+      makeRequest(installationPayload({ latitude: 48.5, longitude: 2.5 })),
+      env,
+    );
+
+    const [point] = ae.writeDataPoint.mock.calls[0];
+    expect(point.blobs[6]).toBe("Cfb");
+  });
+
+  it("writes nothing to Analytics Engine for a non-installation payload", async () => {
+    const { env, ae } = makeEnvWithAE(createFakeBucket());
+
+    await worker.fetch(makeRequest(metricsPayload()), env);
+
+    expect(ae.writeDataPoint).not.toHaveBeenCalled();
+  });
+});
+
+describe("secondary sinks must never change the response", () => {
+  // The same defect class #324 fixed: a failure in a sink that is not the
+  // contract turning into a client-visible error, hence a retry and a double
+  // write. R2 is the contract; the rate-limit marker and Analytics Engine are
+  // not. Both catches are deliberately silent, so nothing but a failing fake
+  // can prove they are still there.
+  it("still answers 202 when the Analytics Engine write throws", async () => {
+    const bucket = createFakeBucket();
+    const { env, ae } = makeEnvWithAE(bucket, { fail: true });
+
+    const res = await worker.fetch(makeRequest(installationPayload()), env);
+
+    expect(res.status).toBe(202);
+    expect(ae.writeDataPoint).toHaveBeenCalledTimes(1);
+    expect(bucket.put).toHaveBeenCalledTimes(1);
+  });
+
+  it("still answers 202 when committing the rate-limit marker fails", async () => {
+    const bucket = createFakeBucket();
+    fakeCache.put.mockRejectedValueOnce(new Error("cache unavailable"));
+
+    const res = await worker.fetch(makeRequest(metricsPayload()), makeEnv(bucket));
+
+    expect(res.status).toBe(202);
+    expect(bucket.put).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("the rate-limit marker actually expires", () => {
+  it("stores a marker whose lifetime is the advertised window", async () => {
+    // The fake cache never expires anything, so a marker written with no TTL
+    // (blocking a unit forever) or a zero one (no limiting at all) passes every
+    // other test in this file while still answering Retry-After: 60.
+    const bucket = createFakeBucket();
+
+    await worker.fetch(makeRequest(metricsPayload()), makeEnv(bucket));
+
+    const [[, stored]] = fakeCache.put.mock.calls;
+    expect(stored.headers.get("cache-control")).toBe("max-age=60");
+  });
+});
+
+describe("payload types that had no test at all", () => {
+  // daily_stats and snapshot were never exercised end to end, so their
+  // whitelists — the final anonymization step before permanent archival — were
+  // deletable without a single failure.
+  function dailyStatsPayload(data: Record<string, unknown> = {}) {
+    return {
+      type: "daily_stats",
+      instance_hash: HASH,
+      date: "2026-03-13",
+      data: { outdoor_temp_avg: 7.5, cop_avg: 3.2, compressor_starts: 12, ...data },
+    };
+  }
+
+  function snapshotPayload(registers: Record<string, unknown> = {}) {
+    return {
+      type: "snapshot",
+      instance_hash: HASH,
+      time: "2026-03-13T12:00:00Z",
+      profile: "yutaki_s80",
+      gateway_type: "modbus_atw_mbs_02",
+      registers: { outdoor_temp: 5, water_inlet_temp: 35, ...registers },
+    };
+  }
+
+  it("accepts a daily_stats payload and partitions it by its own date", async () => {
+    const bucket = createFakeBucket();
+
+    const res = await worker.fetch(makeRequest(dailyStatsPayload()), makeEnv(bucket));
+
+    expect(res.status).toBe(202);
+    expect(writtenKey(bucket)).toBe(
+      `daily_stats/year=2026/month=03/daily_2026-03-13_${HASH.slice(0, 12)}.json`,
+    );
+  });
+
+  it("strips unknown fields from daily_stats before archiving", async () => {
+    const bucket = createFakeBucket();
+
+    await worker.fetch(
+      makeRequest(dailyStatsPayload({ postcode: "75011", owner: "someone" })),
+      makeEnv(bucket),
+    );
+
+    const archived = JSON.parse(bucket.put.mock.calls[0][1] as unknown as string);
+    expect(archived.data.postcode).toBeUndefined();
+    expect(archived.data.owner).toBeUndefined();
+    expect(archived.data.cop_avg).toBe(3.2);
+  });
+
+  it("accepts a snapshot payload and partitions it by ingestion date", async () => {
+    const bucket = createFakeBucket();
+
+    const res = await worker.fetch(makeRequest(snapshotPayload()), makeEnv(bucket));
+
+    expect(res.status).toBe(202);
+    expect(writtenKey(bucket)).toMatch(
+      /^snapshots\/year=\d{4}\/month=\d{2}\/day=\d{2}\/snap_/,
+    );
+    expect(writtenKey(bucket).endsWith(`_${HASH.slice(0, 12)}.json`)).toBe(true);
+  });
+
+  it("keeps only finite numeric registers in a snapshot", async () => {
+    const bucket = createFakeBucket();
+
+    await worker.fetch(
+      makeRequest(
+        snapshotPayload({ serial: "SN-12345", nested: { a: 1 }, broken: null }),
+      ),
+      makeEnv(bucket),
+    );
+
+    const archived = JSON.parse(bucket.put.mock.calls[0][1] as unknown as string);
+    expect(archived.registers.outdoor_temp).toBe(5);
+    expect(archived.registers.serial).toBeUndefined();
+    expect(archived.registers.nested).toBeUndefined();
+    expect(archived.registers.broken).toBeUndefined();
+  });
+
+  it("rate-limits each payload type on its own window", async () => {
+    const env = makeEnv(createFakeBucket());
+
+    const first = await worker.fetch(makeRequest(metricsPayload()), env);
+    const second = await worker.fetch(makeRequest(dailyStatsPayload()), env);
+    const third = await worker.fetch(makeRequest(metricsPayload()), env);
+
+    expect(first.status).toBe(202);
+    expect(second.status).toBe(202); // a different type, so a different window
+    expect(third.status).toBe(429); // same type inside the window
+  });
+});
+
+describe("the identity gate", () => {
+  it("rejects an instance_hash that is not a SHA-256 hex string", async () => {
+    // The hash goes into R2 object keys and the Analytics Engine index, so an
+    // arbitrary string here pollutes the archive's partitioning.
+    const bucket = createFakeBucket();
+    const request = new Request("https://telemetry.internal/v1/ingest", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ...metricsPayload(), instance_hash: "../../etc/passwd" }),
+    });
+
+    const res = await worker.fetch(request, makeEnv(bucket));
+
+    expect(res.status).toBe(400);
+    expect(bucket.put).not.toHaveBeenCalled();
+  });
+
+  it("rejects a body whose instance_hash contradicts the header", async () => {
+    const bucket = createFakeBucket();
+    const request = new Request("https://telemetry.internal/v1/ingest", {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-instance-hash": "a".repeat(64) },
+      body: JSON.stringify(metricsPayload()), // body says HASH, header says a…a
+    });
+
+    const res = await worker.fetch(request, makeEnv(bucket));
+
+    expect(res.status).toBe(400);
+    expect(bucket.put).not.toHaveBeenCalled();
+  });
+
+  it("caps the number of points in one batch", async () => {
+    // The remaining volume bound below the byte limit.
+    const bucket = createFakeBucket();
+    const points = Array.from({ length: 501 }, () => ({
+      time: "2026-03-13T12:00:00Z",
+      outdoor_temp: 5,
+    }));
+
+    const res = await worker.fetch(
+      makeRequest({ ...metricsPayload(), points }),
+      makeEnv(bucket),
+    );
+
+    expect(res.status).toBe(400);
+    expect(bucket.put).not.toHaveBeenCalled();
+  });
+
+  it("keeps only primitive values inside a metrics point", async () => {
+    const bucket = createFakeBucket();
+
+    await worker.fetch(
+      makeRequest({
+        ...metricsPayload(),
+        points: [
+          { time: "2026-03-13T12:00:00Z", outdoor_temp: 5, nested: { secret: 1 } },
+        ],
+      }),
+      makeEnv(bucket),
+    );
+
+    const archived = JSON.parse(bucket.put.mock.calls[0][1] as unknown as string);
+    expect(archived.points[0].outdoor_temp).toBe(5);
+    expect(archived.points[0].nested).toBeUndefined();
+  });
+
+  it("answers 400, not 500, on a body that is not JSON", async () => {
+    const request = new Request("https://telemetry.internal/v1/ingest", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{not json",
+    });
+
+    const res = await worker.fetch(request, makeEnv(createFakeBucket()));
+
+    expect(res.status).toBe(400);
+  });
+
+  it("answers 404 off the ingest path and 405 on the wrong method", async () => {
+    const env = makeEnv(createFakeBucket());
+
+    const wrongPath = await worker.fetch(
+      new Request("https://telemetry.internal/", { method: "POST" }),
+      env,
+    );
+    const wrongMethod = await worker.fetch(
+      new Request("https://telemetry.internal/v1/ingest", { method: "GET" }),
+      env,
+    );
+
+    expect(wrongPath.status).toBe(404);
+    expect(wrongMethod.status).toBe(405);
+  });
+});
+
+describe("object metadata", () => {
+  it("tags every archived object with its identity and type", async () => {
+    // customMetadata is what lets a bucket listing be filtered without opening
+    // each object, so it is part of the archive's contract, not decoration.
+    const bucket = createFakeBucket();
+
+    await worker.fetch(makeRequest(metricsPayload()), makeEnv(bucket));
+
+    const [, , options] = bucket.put.mock.calls[0];
+    expect(options.customMetadata).toMatchObject({ instance_hash: HASH, type: "metrics" });
+    expect(options.httpMetadata.contentType).toBe("application/json");
   });
 });


### PR DESCRIPTION
## Description

The deploy guard from #417 was audited adversarially, by mutation, along with the Worker test suite. It found three ways past the guard and one test that asserts a branch it never reaches. All four are mine; this closes them.

### :bricks: The three bypasses

**`make worker-deploy` hung on any interactive terminal.** `npm test` was `vitest`, not `vitest run`, so the target entered watch mode and never returned. It fails safe on a red suite, but the plausible reaction to a hung deploy is Ctrl-C then `npx wrangler deploy` by hand, which is exactly the unguarded command the target exists to replace. The watcher moves to `npm run test:watch`.

**`npm run deploy` was an unguarded synonym.** `package.json` exposed `"deploy": "wrangler deploy"`, the muscle-memory command for anyone who has worked on a Worker before. Removed.

**`-include` of the local `.env` was a live hazard.** It parses the whole file into make's namespace, so one line make cannot parse broke **every** target in this repository, `make test` included, and any assignment silently overrode a Makefile variable: a `.env` copied from another project could repoint `WORKER_DIR`. It now extracts that single value instead.

Checked against every shape the audit tried, and a few more:

| `.env` content | Before | After |
|---|---|---|
| absent | ok | ok, guard fires |
| `CLOUDFLARE_ACCOUNT_ID=abc123` | ok | ok |
| quoted, or single-quoted | quotes reached wrangler | stripped |
| spaces around `=`, trailing blanks | leaked into the value | stripped |
| CRLF | machine-dependent | stripped |
| `export CLOUDFLARE_ACCOUNT_ID=…` | ok | ok |
| a line make cannot parse | **every target in the repo broken** | ignored |
| `WORKER_DIR=/nonexistent` | **silently repointed the targets** | ignored |
| value exported in the shell | wins | wins (unchanged) |

Also: the provisioning section of `backend/README.md` still showed a bare `wrangler r2 bucket create`, which targets the OAuth-default account with no guard at all. That is the bucket half of the original accident, so it now names the account too.

### :test_tube: The dead test

`JSON.stringify(Number.NaN)` emits `null`, so `"drops a NaN where a number is expected"` was exercising the `typeof` check, and the `Number.isFinite` guard beside it was covered by nothing. Deleting that guard passed the whole suite.

The guard is **live code, not dead**. The two reviewers disagreed on this and I settled it by running it: the JSON grammar has no `Infinity` literal, but an exponent that overflows parses to one.

```
JSON.parse('{"latitude": 1e999}').latitude  // Infinity, typeof "number"
```

Without the guard that reaches the R2 archive and the Analytics Engine `doubles`. The test is renamed for what it actually does and a real overflow case added; removing the guard now fails it. Suite 20 to 21.

### :warning: What this does NOT fix

The guard still checks that an account id is **present**, never that it is the **right one**. A stale `CLOUDFLARE_ACCOUNT_ID` exported from another project satisfies it and re-creates the original silent wrong-account deploy, which the audit demonstrated end to end. Closing that means pinning the identity: committing `account_id` to `wrangler.toml`, or asserting `wrangler whoami` names the expected account. That is a separate decision, tracked in #414's follow-up discussion, deliberately not made here.

## Checklist

- [x] Tests pass (`make test`, `make worker-test`)
- [x] Code quality checks pass (`make check`)
- [ ] `CHANGELOG.md` updated under `[Unreleased]` (tooling and tests only, no user-facing effect, `skip-changelog`)
- [x] New/modified entities follow [architecture rules](docs/architecture.md)
- [x] Documentation updated for any behavior/architecture/register/entity/workflow change
- [ ] Translation keys added to `translations/en.json` (not applicable)

https://claude.ai/code/session_01NtnPkzmrbFvS47641Mhwgd