### PR TITLE
release: 2.2.0-beta.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0-beta.4] - 2026-08-31
+
 ### Fixed
 - Telemetry on installations with more than one Hitachi gateway: every config entry
   shared a single `instance_hash` derived from the Home Assistant instance, so the

--- a/custom_components/hitachi_yutaki/manifest.json
+++ b/custom_components/hitachi_yutaki/manifest.json
@@ -15,5 +15,5 @@
   "requirements": [
     "pymodbus>=3.6.9,<4.0.0"
   ],
-  "version": "2.2.0-beta.3"
+  "version": "2.2.0-beta.4"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hass-hitachi-yutaki"
-version = "2.2.0-beta.3"
+version = "2.2.0-beta.4"
 requires-python = ">=3.13.2"
 description = "Home Assistant custom integration for Hitachi Yutaki heat pumps"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1151,7 +1151,7 @@ wheels = [
 
 [[package]]
 name = "hass-hitachi-yutaki"
-version = "2.2.0b2"
+version = "2.2.0b4"
 source = { virtual = "." }
 dependencies = [
     { name = "pymodbus" },


### PR DESCRIPTION
## Description

Version bump for `2.2.0-beta.4`, and the `[Unreleased]` CHANGELOG entries moved under a dated section.

Telemetry only, from a user's point of view. The release carries the per-gateway identity work for #395 and the buffer and transport defects an adversarial review of that branch turned up along the way.

### :satellite: What testers will notice

Nothing, unless they have **more than one Hitachi gateway** and telemetry enabled, in which case it starts working. Before this, every config entry on one Home Assistant instance shared a single identity, so the ingestion endpoint rate-limited all but one of them into permanent silence.

Single-gateway installations are unaffected and their fleet history stays continuous.

### :handshake: The other half is already live

The Worker that reads these payloads was deployed today (version `71a3c315`), along with four archive fixes from #414. So this release meets an endpoint that already understands `device_hash` rather than ignoring it. Verified against production: a malformed `device_hash` now returns `400 Invalid device_hash`, which only the new code can say.

### :clipboard: Notes

- `make bump PART=beta` touched `manifest.json` and `pyproject.toml`; the CHANGELOG move is the manual step the release template calls for, with `## [Unreleased]` left in place and empty.
- The backend PRs in this window (#415, #416, #417, #418) carry `skip-changelog`: they change the Worker and the tooling, not the integration.
- Publishing as a **pre-release**, so `2.1.6` stays "Latest" and default HACS users are not offered it.

## Checklist

- [x] Tests pass (`make test`) — 610
- [x] Code quality checks pass (`make check`)
- [x] `CHANGELOG.md` updated (entries dated under `2.2.0-beta.4`)
- [x] New/modified entities follow [architecture rules](docs/architecture.md)
- [x] Documentation updated for any behavior/architecture/register/entity/workflow change
- [ ] Translation keys added to `translations/en.json` (not applicable, no user-facing strings)

https://claude.ai/code/session_01NtnPkzmrbFvS47641Mhwgd