### PR TITLE
chore(ci): fail the build when uv.lock drifts from pyproject.toml

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
         run: uv python install 3.14
 
       - name: Install dependencies
-        run: uv sync --group dev
+        run: uv sync --locked --group dev
 
       - name: Lint with ruff
         run: uv run ruff check custom_components tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,7 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync --group dev
+        run: uv sync --locked --group dev
 
       - name: Pin HA ${{ matrix.ha-version }}
         if: matrix.phac-version != ''


### PR DESCRIPTION
## What

`uv sync --group dev` becomes `uv sync --locked --group dev` in `lint.yml` and `tests.yml`.

## Why

Follow-up to #421. Without `--locked`, uv re-resolves from `pyproject.toml` and installs the correct versions even when `uv.lock` is stale, so a lock file out of sync with the manifest never fails a build. That is exactly how the ruff bump in #412 merged with `pyproject.toml` on `0.16.4` and `uv.lock` still on `0.15.20`.

With `--locked`, uv verifies the lock matches the manifest and fails otherwise, so the drift surfaces on the PR that introduces it rather than sitting on `main`.

## Consequences

Dependabot's `pip` ecosystem updates `pyproject.toml` without touching `uv.lock`, so its dependency PRs will now fail this step until the lock is refreshed. That is the intended signal: the fix is a `uv lock` commit pushed onto the Dependabot branch, as was done for #412.

The HA-version pinning step in `tests.yml` runs `uv pip install` after the sync, so it is unaffected.

Verified locally: `uv sync --locked --group dev` resolves clean against the lock merged in #421.

No user-facing effect, hence `skip-changelog`.

https://claude.ai/code/session_01NtnPkzmrbFvS47641Mhwgd