### PR TITLE
chore: add ty type checker, advisory and scoped to the domain layer

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,3 +29,23 @@ jobs:
 
       - name: Check translation keys
         run: uv run python scripts/check_translations.py
+
+  # ty is still 0.0.x: advisory only, never a required status check. Findings
+  # surface as annotations without blocking the PR.
+  typecheck:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python 3.14
+        run: uv python install 3.14
+
+      - name: Install dependencies
+        run: uv sync --locked --group dev
+
+      - name: Type-check the domain layer with ty
+        run: uv run ty check custom_components/hitachi_yutaki/domain

--- a/AGENT.md
+++ b/AGENT.md
@@ -123,7 +123,7 @@ Domain logic goes in `domain/services/`, adapter logic in `adapters/`. See [docs
 
 ## Code Quality Standards
 - **Linting**: Ruff with the Home Assistant ruleset (configured in `pyproject.toml` under `[tool.ruff]`).
-- **Type checking**: `ty` (Astral, pinned while pre-1.0), advisory only and scoped to the pure-Python domain layer via `make typecheck`. Not part of `make check`, pre-commit, or required CI checks until ty reaches 1.0.
+- **Type checking**: `ty` (Astral, pinned while pre-1.0), advisory only and scoped to the pure-Python domain layer via `make typecheck`. Not part of `make check`, pre-commit, or required CI checks until ty reaches 1.0; a non-blocking CI job (`typecheck` in `lint.yml`) surfaces findings on PRs.
 - **Type hints**: required for all function signatures.
 - **Docstrings**: required for all public functions/classes.
 - **Import conventions**: use the aliases from `[tool.ruff.lint.flake8-import-conventions.extend-aliases]` in `pyproject.toml` (e.g., `vol`, `cv`, `dt_util`).

--- a/AGENT.md
+++ b/AGENT.md
@@ -15,6 +15,7 @@ make setup           # Full project setup (deps + pre-commit hooks)
 make install         # Install/reinstall all dependencies
 make check           # Run all code quality checks (lint + format)
 make lint            # Run ruff linter with auto-fix
+make typecheck       # Type-check the domain layer with ty (advisory, beta tool)
 make test            # Run all tests
 make test-domain     # Run domain layer tests only (pure Python, no HA)
 make test-coverage   # Run tests with coverage report
@@ -122,6 +123,7 @@ Domain logic goes in `domain/services/`, adapter logic in `adapters/`. See [docs
 
 ## Code Quality Standards
 - **Linting**: Ruff with the Home Assistant ruleset (configured in `pyproject.toml` under `[tool.ruff]`).
+- **Type checking**: `ty` (Astral, pinned while pre-1.0), advisory only and scoped to the pure-Python domain layer via `make typecheck`. Not part of `make check`, pre-commit, or required CI checks until ty reaches 1.0.
 - **Type hints**: required for all function signatures.
 - **Docstrings**: required for all public functions/classes.
 - **Import conventions**: use the aliases from `[tool.ruff.lint.flake8-import-conventions.extend-aliases]` in `pyproject.toml` (e.g., `vol`, `cv`, `dt_util`).
@@ -136,7 +138,7 @@ Tests live in `tests/` (mirrors the package layout):
 ## Dependencies
 All dependencies are declared in `pyproject.toml` (single source of truth).
 - **Runtime**: `pymodbus`, Home Assistant core.
-- **Dev**: `pytest-homeassistant-custom-component`, `ruff`, `pre-commit`, `pytest`, `pytest-asyncio`.
+- **Dev**: `pytest-homeassistant-custom-component`, `ruff`, `ty`, `pre-commit`, `pytest`, `pytest-asyncio`.
 
 ## Operating Modes (preserved conventions)
 

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,13 @@ format: ## Run ruff formatter
 .PHONY: check
 check: lint format ## Run all code quality checks (lint + format)
 
+# ty is still 0.0.x (pinned in pyproject.toml): advisory only, scoped to the
+# pure-Python domain layer, and deliberately not part of `check`, pre-commit
+# or required CI checks until it reaches 1.0.
+.PHONY: typecheck
+typecheck: ## Type-check the domain layer with ty (advisory, beta tool)
+	uv run ty check custom_components/hitachi_yutaki/domain
+
 .PHONY: pre-commit
 pre-commit: ## Run all pre-commit hooks on the entire codebase
 	uv run pre-commit run --all-files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dev = [
     "ruff==0.16.4",
     "pre-commit>=4.3.0",
     "colorlog>=6.9.0",
+    "ty==0.0.77",
 ]
 
 [tool.pytest.ini_options]

--- a/uv.lock
+++ b/uv.lock
@@ -1165,6 +1165,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-homeassistant-custom-component" },
     { name = "ruff" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -1178,6 +1179,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-homeassistant-custom-component" },
     { name = "ruff", specifier = "==0.16.4" },
+    { name = "ty", specifier = "==0.0.77" },
 ]
 
 [[package]]
@@ -2707,6 +2709,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.77"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ef/a2024d1d33d5ba8436677a6fd734f87a137150aba99906fc009f7c5de956/ty-0.0.77.tar.gz", hash = "sha256:8898f3097610f4a772ead6bfad7b204c7d76e8eb3a010c7285b9186278e0fb82", size = 7005734, upload-time = "2026-09-01T00:26:26.901Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/03/930f7454a6d797abc09aebbf537017825ebb08d9f8c2e2d905e74341dbb1/ty-0.0.77-py3-none-linux_armv6l.whl", hash = "sha256:ea76012f1ed387b6fc6500894fb8a7654b724c38713e263a23f12756f00e2469", size = 13241626, upload-time = "2026-09-01T00:25:51.02Z" },
+    { url = "https://files.pythonhosted.org/packages/65/41/7e064045775718673851f6c0e1cfde70d6e380b0db9d91d4484a362f2d67/ty-0.0.77-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:237a58c389e01d65c4693e0394feb0f0adea3fba0345c3b932d209084372f3d3", size = 12830037, upload-time = "2026-09-01T00:25:53.172Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/64/66f0b0dc89bd239922bdf12fa3e6d066aa7a425e8b70414368c4eb44a6e6/ty-0.0.77-py3-none-macosx_11_0_arm64.whl", hash = "sha256:bbb8ae7a753b9a6af25725c314d0eca967e5fde5eebb7a35b04b0d763dfb9d7c", size = 12612071, upload-time = "2026-09-01T00:25:55.116Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/5c/bef8b1f471931a9395792be023613b6cee0ef1449815bf97b18be07f883c/ty-0.0.77-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:603620c063b718ddbe302f83fb0d7c01a13f1941c3b9763512a89c9bbfabba96", size = 12641403, upload-time = "2026-09-01T00:25:57.305Z" },
+    { url = "https://files.pythonhosted.org/packages/43/66/e4d32a0145162f79bc3dd6fca4770f88966c3b5206121ffeecd5f7b05e8b/ty-0.0.77-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03f128cb8b204e22a18f4b01ef0194aa445f4edb080cb7d77621cb2ab353885c", size = 13013526, upload-time = "2026-09-01T00:25:59.278Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/be/33493ee43d4db7d402ceaee55c5d6c22e2b1105f10b1ac5928c220f79650/ty-0.0.77-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:97d1600ef69fc8e3b2310de1915cd34ba3b712fdc730cb02b713520956baec0a", size = 13828076, upload-time = "2026-09-01T00:26:01.343Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/d5/b6335fdc8c09aaaaf6541322076c5a7205fa16c29dbeddc1f24dd89b3894/ty-0.0.77-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dced0924a83b6d945fd48a29aa85e131fb98dc574f4c9a0e7c43d03eff373402", size = 14247770, upload-time = "2026-09-01T00:26:03.388Z" },
+    { url = "https://files.pythonhosted.org/packages/11/64/bbe96c1da26585919ac10f33df1d337d9b498013fc60c5178e76955c2a53/ty-0.0.77-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b14b002233a954115a04932b3a93d75a387569848276cf7bb0b5dc6b040001c4", size = 13926528, upload-time = "2026-09-01T00:26:05.587Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/e2/cdc94e9a1b69e9b7dd0ec3ad3ca75741245b8b5b2e3ffe9b365ca31d8052/ty-0.0.77-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:581adf1ae1e48e00e89ec162913d559ddf75a7805646a13ffd68943c1b5e8daa", size = 13290834, upload-time = "2026-09-01T00:26:07.912Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8c/4929dd8e924ddbd6284dcb3cfbda488bd6cb091e5384f8b7fb5dd3de9122/ty-0.0.77-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9bda523b40e06c643feb6d5d5bcbacc56a2bd9eed3d7cae1119452502bcd69b0", size = 13829048, upload-time = "2026-09-01T00:26:10.093Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f4/441a74ddc5e2db2690264c1ee0e478d46b8e42bd529472fdb1656b63bff2/ty-0.0.77-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4b8b04d8c3af8148e963e950094bd53c8cc4d3a11f5f8764ff8d39627bd6e64a", size = 12803755, upload-time = "2026-09-01T00:26:12.055Z" },
+    { url = "https://files.pythonhosted.org/packages/85/39/875bb7092ee1edb090b62eca74b7311f6416dc3aa7da442b4a1f95408251/ty-0.0.77-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:33a9ff9be488edf4d6fac46c456198cc848d9641f418f1a83aa123825e93c6ec", size = 13028244, upload-time = "2026-09-01T00:26:14.212Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/76/4b0a48f118dca6a32e1609f2d0bea2c3f7be9051af645fe5044ca35cbbb4/ty-0.0.77-py3-none-musllinux_1_2_i686.whl", hash = "sha256:61ad5467206e5ea6531c8aebebf1276c6150989a94a1d5974a84d9e0eeed5c38", size = 13321068, upload-time = "2026-09-01T00:26:16.418Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/46/cd21bc6441df4b221d9e131551bab2a5f9c0b724e60e1c960622ee175128/ty-0.0.77-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1293b94f26d1f330424e3b97c20b434f7e2ac1938287b8588466c75ece6c0b10", size = 13609112, upload-time = "2026-09-01T00:26:18.424Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7b/0da4537a7eca4eb3ca72a2cb4539cfbb6fb3138d1dc4ae7a66299b941fb3/ty-0.0.77-py3-none-win32.whl", hash = "sha256:cb71152bdf56860375c790682cc3efc120aaf8e36f1cd6367773312905e82b50", size = 12573821, upload-time = "2026-09-01T00:26:20.404Z" },
+    { url = "https://files.pythonhosted.org/packages/96/91/aec75b11bfaa5a358f5a505afa6307fc4bee1c5f4c6444e18fa82c25f3be/ty-0.0.77-py3-none-win_amd64.whl", hash = "sha256:86f01d4af8b006c9442a2de0ab949cc24462f8f9431bebc0b73f6166fbbca19f", size = 13154851, upload-time = "2026-09-01T00:26:22.389Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e5/77772f95ff81bf7c817595cd08b52d007acab90dac0f2339faa486e6a525/ty-0.0.77-py3-none-win_arm64.whl", hash = "sha256:942a3bb2a4786c80bd8ef4503e5024046617cdfcc550b56c1acc4817ce7ac144", size = 12992392, upload-time = "2026-09-01T00:26:24.44Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Adds [ty](https://docs.astral.sh/ty/), Astral's type checker, to the dev toolchain — a natural fit alongside uv and ruff, which the project already uses.

Since ty is still pre-1.0 (0.0.x, diagnostics may change between versions), it is introduced deliberately conservatively:

- **Pinned exactly** (`ty==0.0.77`), like ruff.
- **Scoped to the pure-Python domain layer** (`custom_components/hitachi_yutaki/domain/`), which is stdlib-only and gives a clean signal without the false positives HA patterns tend to trigger.
- **Advisory only**: new `make typecheck` target, not part of `make check`, pre-commit, or required CI checks. To be widened and hardened once ty reaches 1.0.

The first run reports 13 pre-existing diagnostics (Optional narrowing in `domain/services/cop.py` and `domain/services/refrigerant.py`), left as-is here — they are candidates for a follow-up cleanup.

## Checklist

- [x] Tests pass (`make test`) — no runtime code touched
- [x] Code quality checks pass (`make check`)
- [x] `CHANGELOG.md` updated under `[Unreleased]` (or `skip-changelog` label added)
- [ ] New/modified entities follow architecture rules — N/A
- [x] Documentation updated (`AGENT.md`: commands, code quality standards, dependencies)
- [ ] Translation keys — N/A

https://claude.ai/code/session_01Wu6aVNZ1HUeKnvNR1oKrY4