### PR TITLE
chore: make the domain layer pass ty by narrowing Optional signals

### DIFF
--- a/custom_components/hitachi_yutaki/domain/services/cop.py
+++ b/custom_components/hitachi_yutaki/domain/services/cop.py
@@ -205,14 +205,15 @@ class COPService:
             return
 
         # Validate input data
-        if any(
-            x is None
-            for x in [
-                data.water_inlet_temp,
-                data.water_outlet_temp,
-                data.water_flow,
-                data.compressor_current,
-            ]
+        water_inlet_temp = data.water_inlet_temp
+        water_outlet_temp = data.water_outlet_temp
+        water_flow = data.water_flow
+        compressor_current = data.compressor_current
+        if (
+            water_inlet_temp is None
+            or water_outlet_temp is None
+            or water_flow is None
+            or compressor_current is None
         ):
             # Transient missing data: do not advance the interval timer, so the
             # next complete poll within the interval is still accepted (#319).
@@ -223,9 +224,9 @@ class COPService:
 
         # Calculate thermal power
         thermal_power = self._thermal_calculator(
-            data.water_inlet_temp,  # type: ignore
-            data.water_outlet_temp,  # type: ignore
-            data.water_flow,  # type: ignore
+            water_inlet_temp,
+            water_outlet_temp,
+            water_flow,
         )
 
         # Use pre-computed electrical power if available, else compute from current.
@@ -236,7 +237,7 @@ class COPService:
         if data.electrical_power is not None:
             electrical_power = data.electrical_power
         else:
-            total_current = data.compressor_current  # type: ignore
+            total_current = compressor_current
             if (
                 data.secondary_compressor_current is not None
                 and data.secondary_compressor_frequency is not None

--- a/custom_components/hitachi_yutaki/domain/services/refrigerant.py
+++ b/custom_components/hitachi_yutaki/domain/services/refrigerant.py
@@ -141,21 +141,35 @@ class RefrigerantMonitor:
         if current - self._last_sample_time < SAMPLE_MIN_INTERVAL_S:
             return flushed
 
-        superheat = data.gas_temp - data.evaporator_temp  # type: ignore[operator]
+        gas_temp = data.gas_temp
+        evaporator_temp = data.evaporator_temp
+        outdoor_expansion_valve = data.outdoor_expansion_valve
+        outdoor_temp = data.outdoor_temp
+        if (
+            gas_temp is None
+            or evaporator_temp is None
+            or outdoor_expansion_valve is None
+            or outdoor_temp is None
+        ):
+            # Already rejected by _should_sample(); repeated on locals so the
+            # signals are narrowed to float for the checks below.
+            return flushed
+
+        superheat = gas_temp - evaporator_temp
         if not (self._superheat_min <= superheat <= self._superheat_max):
             return flushed
-        if not (EVO_MIN_PCT <= data.outdoor_expansion_valve <= EVO_MAX_PCT):  # type: ignore[operator]
+        if not (EVO_MIN_PCT <= outdoor_expansion_valve <= EVO_MAX_PCT):
             return flushed
-        if not (EVAP_MIN_C <= data.evaporator_temp <= EVAP_MAX_C):  # type: ignore[operator]
+        if not (EVAP_MIN_C <= evaporator_temp <= EVAP_MAX_C):
             return flushed
-        if not (OUTDOOR_MIN_C <= data.outdoor_temp <= OUTDOOR_MAX_C):  # type: ignore[operator]
+        if not (OUTDOOR_MIN_C <= outdoor_temp <= OUTDOOR_MAX_C):
             return flushed
 
         self._last_sample_time = current
         self._superheats.append(superheat)
-        self._evos.append(data.outdoor_expansion_valve)  # type: ignore[arg-type]
-        self._evaps.append(data.evaporator_temp)  # type: ignore[arg-type]
-        self._outdoors.append(data.outdoor_temp)  # type: ignore[arg-type]
+        self._evos.append(outdoor_expansion_valve)
+        self._evaps.append(evaporator_temp)
+        self._outdoors.append(outdoor_temp)
         return flushed
 
     def get_status(self) -> RefrigerantStatus:


### PR DESCRIPTION
## Description

Follow-up to #423: clears the 13 pre-existing ty diagnostics so `make typecheck` (and the advisory `typecheck` CI job) is green.

Both files guarded `None` behind constructs a type checker cannot see through — `any()` over a list in `domain/services/cop.py`, the `_should_sample()` helper in `domain/services/refrigerant.py`. The fix binds the Optional signals to locals and narrows them explicitly:

- **`cop.py`**: the `any(x is None for x in [...])` guard becomes explicit `is None` checks on local bindings, which the downstream calculations then use. Drops 4 `type: ignore` comments.
- **`refrigerant.py`**: `_should_sample()` already rejects `None` signals, but the call is opaque to the checker; a redundant (commented as such) guard on locals narrows them before the range checks. Drops 7 `type: ignore` comments.

No behavior change: the guards reject exactly the same inputs as before. The mypy-style ignores, which ty did not honor anyway, are gone.

## Checklist

- [x] Tests pass (`make test`) — 612 passed
- [x] Code quality checks pass (`make check`) — ruff and `make typecheck` both green
- [x] `CHANGELOG.md` updated under `[Unreleased]` (or `skip-changelog` label added)
- [ ] New/modified entities follow architecture rules — N/A
- [ ] Documentation updated — N/A (internal narrowing, no doc statement affected)
- [ ] Translation keys — N/A

https://claude.ai/code/session_01Wu6aVNZ1HUeKnvNR1oKrY4