### PR TITLE
fix: read the configured power sensor even when the compressor reports 0 A

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- A configured **Power Sensor** (`power_entity`) is now read even when the compressor reports 0 A. The electrical-power computation was guarded by `compressor_current > 0`, but the measured-power path does not use the current at all, so the external meter was simply ignored whenever the compressor current read zero: standby draw was never counted for anyone, and wherever the gateway itself reports a constant 0 A (an **HC-A(16/64)MB** serves no compressor current for a unit read at a secondary refrigerant cycle, even with the compressor running) `electrical_power`, `power_consumption` and `electricity_cost` were stuck at 0 forever, even with a dedicated meter correctly configured. The `P ≈ U × I × cosφ` estimate is unchanged. Note that DHW COP still cannot be computed on a Yutampo R32: it requires water inlet/outlet temperatures and flow, which that unit does not report (#403).
+
 ## [2.2.0-beta.4] - 2026-08-31
 
 ### Fixed

--- a/custom_components/hitachi_yutaki/adapters/derived_metrics.py
+++ b/custom_components/hitachi_yutaki/adapters/derived_metrics.py
@@ -307,7 +307,6 @@ class DerivedMetricsAdapter:
         # Summing the currents first is correct for both backends:
         #   - measured_power path: returned once (whole unit) -> no double count.
         #   - I×U estimate path: U×(I1+I2) == U×I1 + U×I2 -> identical to old sum.
-        electrical_power = 0.0
         current = data.get("compressor_current")
         total_current = current if current is not None and current > 0 else 0.0
 
@@ -318,8 +317,16 @@ class DerivedMetricsAdapter:
             if sec_current is not None and sec_freq is not None and sec_freq > 0:
                 total_current += sec_current
 
-        if total_current > 0:
-            electrical_power = self._electrical_calculator(total_current)
+        # Issue #403: the calculator is called unconditionally, including at
+        # zero current. Its priority-1 branch reads CONF_POWER_ENTITY, which
+        # does not use the current at all, so a `total_current > 0` guard made
+        # an external power meter unreadable whenever the compressor reported
+        # 0 A: standby draw for everyone, and permanently wherever the gateway
+        # itself reports a constant 0 A (an HC-A(16/64)MB serves no current for
+        # a unit read at a secondary refrigerant cycle, even with the
+        # compressor demonstrably running). The I×U estimate is unaffected
+        # (U × 0 × cosφ == 0).
+        electrical_power = self._electrical_calculator(total_current)
 
         data["electrical_power"] = round(electrical_power, 3)
         _LOGGER.debug(

--- a/custom_components/hitachi_yutaki/profiles/yutampo_r32.py
+++ b/custom_components/hitachi_yutaki/profiles/yutampo_r32.py
@@ -92,8 +92,15 @@ class YutampoR32Profile(HitachiHeatPumpProfile):
         """Return False - compact compressor, reduced sensor package.
 
         Gas temp (Tg), liquid temp (Ti) and expansion valve openings (EVI/EVO)
-        read a constant 0 on a Yutampo R32; only the core compressor sensors
+        read a constant 0 on a Yutampo R32; the core compressor sensors
         (frequency, current, discharge, evaporator) carry real data.
+
+        Caveat (#403): "carries real data" is about the model, not about every
+        installation. Behind an HC-A(16/64)MB gateway, a unit read at a
+        secondary refrigerant cycle gets frequency and current from the gateway
+        as a constant 0 (discharge and evaporator still work) — a gateway
+        limitation that applies whatever the model, so it is not expressed
+        here as a profile capability.
         """
         return False
 

--- a/docs/gateway/hc-a-mb.md
+++ b/docs/gateway/hc-a-mb.md
@@ -471,7 +471,9 @@ Offset 145:
 
 Some state registers about outdoor unit have been added. Using these registers it is now possible to know the status of the refrigerant cycle. Some control registers have also been added.
 
-The outdoor unit block uses a **different**, fixed base from the indoor block (not the indoor `Modbus_Id`): the integration computes outdoor addresses as `30000 + Offset`. The outdoor unit is shared across all indoor units on the same H-LINK bus. Note: the datasheet describes indexing by outdoor refrigerant cycle (`30000 + (Cycle × 100) + Offset`), but the current implementation hardcodes the base at 30000 and does not index by refrigerant cycle (effectively cycle 0 only).
+The outdoor unit block uses a **different** base from the indoor block (not the indoor `Modbus_Id`): it is keyed on the **outdoor refrigerant cycle**, `30000 + (Cycle × 100) + Offset`. The cycle is arbitrary and is *not* the `unit_id`; it is read from the gateway unit table (input register `200 + unit_id × 4 + 1`, `0xFF` meaning "no unit"), persisted at config time as `outdoor_cycle`, and falls back to cycle 0 when it cannot be read (#353, since v2.2.0-beta.1). One outdoor unit is shared by all indoor units sitting on the same refrigerant cycle.
+
+> **Known limitation (#403).** On a gateway hosting several cycles, field data shows the extended outdoor registers populated **only for cycle 0**. At a secondary cycle, offsets `0`/`1`/`2` (outdoor air, discharge, evaporating temperature) carry live values, while `3`~`10` (number of running compressors, pressures, **total current**, **total frequency**, EVO/EVB) stay at `0` even with the compressor demonstrably running. This is a gateway behaviour, not a model limitation: a Yutampo R32 read at cycle 0 reports current and frequency normally. Consequence: on such a unit, `electrical_power` cannot be estimated from the compressor current, and a **Power Sensor** must be configured to get any electrical reading. Not yet confirmed whether a non-Yutampo unit at a non-zero cycle behaves the same.
 
 | Offset | Description | Values | R/W |
 |---|---|---|---|

--- a/docs/reference/domain-services.md
+++ b/docs/reference/domain-services.md
@@ -226,6 +226,15 @@ chain for input data.
 > magnitude. A configured `measured_power` (Power Sensor option) bypasses the
 > estimate entirely (priority 1).
 
+> **Zero current is not a short-circuit.** The adapter calls the calculator on
+> every poll, including when the compressor reports 0 A, because the
+> measured-power branch does not use the current. This is what lets a Power
+> Sensor report standby draw, and what makes it usable at all wherever the
+> gateway itself reports a constant 0 A (an HC-A(16/64)MB serves no current for
+> a unit read at a secondary refrigerant cycle, even with the compressor
+> demonstrably running, #403). With no Power Sensor configured the result is
+> unchanged (`U × 0 × cosφ = 0`).
+
 ### Priority
 
 1. `measured_power` (direct kW reading, if available)

--- a/tests/adapters/test_derived_metrics.py
+++ b/tests/adapters/test_derived_metrics.py
@@ -504,6 +504,62 @@ class TestEnergyAndCost:
         # measured whole-unit power is 3 kW; must NOT be ~6 kW
         assert data["electrical_power"] == 3.0
 
+    def test_power_entity_read_when_current_is_zero(self):
+        """Regression #403: an external power meter must be read at 0 A.
+
+        The measured-power branch does not use the compressor current, so a
+        unit reporting 0 A (permanently on a Yutampo R32, or simply at standby)
+        must still report the meter value.
+        """
+        mock_hass = MagicMock()
+
+        power_state = MagicMock()
+        power_state.state = "749"  # 749 W measured while the compressor runs
+        power_state.attributes = {"unit_of_measurement": "W"}
+
+        config_entry = MagicMock()
+        config_entry.data = {"power_entity": "sensor.unit_power"}
+
+        mock_hass.states.get = lambda entity_id: (
+            power_state if entity_id == "sensor.unit_power" else None
+        )
+
+        adapter = DerivedMetricsAdapter(
+            hass=mock_hass,
+            config_entry=config_entry,
+            power_supply="single",
+        )
+
+        data = _sample_data(compressor_current=0, compressor_frequency=0)
+        adapter.update(data)
+        assert data["electrical_power"] == 0.749
+
+    def test_power_entity_read_when_current_is_missing(self):
+        """Regression #403: same, when the register is absent from the payload."""
+        mock_hass = MagicMock()
+
+        power_state = MagicMock()
+        power_state.state = "0.059"
+        power_state.attributes = {"unit_of_measurement": "kW"}
+
+        config_entry = MagicMock()
+        config_entry.data = {"power_entity": "sensor.unit_power"}
+
+        mock_hass.states.get = lambda entity_id: (
+            power_state if entity_id == "sensor.unit_power" else None
+        )
+
+        adapter = DerivedMetricsAdapter(
+            hass=mock_hass,
+            config_entry=config_entry,
+            power_supply="single",
+        )
+
+        data = _sample_data()
+        data.pop("compressor_current")
+        adapter.update(data)
+        assert data["electrical_power"] == 0.059
+
     def test_s80_ixu_estimate_matches_summed_current(self):
         """S80 I×U estimate is unchanged: U×(I1+I2) == U×I1 + U×I2.
 


### PR DESCRIPTION
## Description

Fixes #403.

A configured **Power Sensor** (`power_entity`) was ignored whenever the compressor reported 0 A. The electrical-power computation in `DerivedMetricsAdapter` was guarded by `total_current > 0`, but the calculator's priority-1 branch (`CONF_POWER_ENTITY`) does not use the current at all, so:

- standby draw was never counted, for anyone with an external meter;
- wherever the gateway itself reports a constant 0 A, `electrical_power`, `power_consumption` and `electricity_cost` were stuck at 0 **forever**, even with a dedicated meter correctly configured. Field data from #403 shows an HC-A(16/64)MB serves no compressor current for a unit read at a secondary refrigerant cycle, even with the compressor demonstrably running.

The calculator is now called unconditionally. The `P ≈ U × I × cosφ` estimate path is unchanged (`U × 0 × cosφ == 0`).

Also documents the underlying gateway limitation: on a multi-cycle HC-A(16/64)MB, the extended outdoor registers (running compressors, pressures, total current/frequency, EVO/EVB) are only populated for cycle 0 (see the new "Known limitation" note in `docs/gateway/hc-a-mb.md`), and a docstring caveat on the Yutampo R32 profile.

Note: DHW COP still cannot be computed on a Yutampo R32 — it requires water inlet/outlet temperatures and flow, which that unit does not report.

## Checklist

- [x] Tests pass (`make test`) — 612 passed, includes new coverage in `tests/adapters/test_derived_metrics.py`
- [x] Code quality checks pass (`make check`)
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] New/modified entities follow architecture rules — N/A (no entity change)
- [x] Documentation updated (`docs/reference/domain-services.md`, `docs/gateway/hc-a-mb.md`)
- [ ] Translation keys — N/A

https://claude.ai/code/session_01Wu6aVNZ1HUeKnvNR1oKrY4